### PR TITLE
[Feat] Kover 셋팅

### DIFF
--- a/.github/workflows/caro-ci.yml
+++ b/.github/workflows/caro-ci.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Collect Kover XML Report Paths
         id: report-paths
+        if: always()
         run: |
           echo "paths<<EOF" >> $GITHUB_OUTPUT
           find . -path "*/build/reports/kover/**/report.xml" >> $GITHUB_OUTPUT

--- a/.github/workflows/caro-ci.yml
+++ b/.github/workflows/caro-ci.yml
@@ -68,18 +68,13 @@ jobs:
       - name: Generate Kover XML
         run: ./gradlew koverAllXmlReport --build-cache --parallel
 
-      - name: Collect Kover XML Report Paths
-        id: report-paths
-        run: |
-          echo "paths<<EOF" >> $GITHUB_OUTPUT
-          find . -path "*/build/reports/kover/report.xml" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
       - name: Comment coverage on PR
         uses: mi-kas/kover-report@v1.9
         with:
           path: |
-            ${{ steps.report-paths.outputs.paths }}
+            core/data/build/reports/kover/report.xml
+            feature/login/build/reports/kover/report.xml
+            feature/home/build/reports/kover/report.xml
           title: ViewModel / Repository Test Coverage
           update-comment: true
           min-coverage-overall: 80

--- a/.github/workflows/caro-ci.yml
+++ b/.github/workflows/caro-ci.yml
@@ -68,7 +68,11 @@ jobs:
       - name: Generate Kover XML
         run: ./gradlew koverAllXmlReport --build-cache --parallel
 
+      - name: Verify coverage
+        run: ./gradlew koverAllVerify --build-cache --parallel
+
       - name: Comment coverage on PR
+        if: always()
         uses: mi-kas/kover-report@v1.9
         with:
           path: |
@@ -79,3 +83,17 @@ jobs:
           update-comment: true
           min-coverage-overall: 80
           coverage-counter-type: LINE
+
+      - name: Slack Notify Coverage Result
+        if: always()
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ job.status == 'success'
+                && format('<{0}|#%s PR> 테스트 커버리지 통과 ✅', github.event.pull_request.html_url, github.event.pull_request.number)
+                || format('<{0}|#%s PR> 테스트 커버리지 미달 ❌', github.event.pull_request.html_url, github.event.pull_request.number)
+              }}"
+            }

--- a/.github/workflows/caro-ci.yml
+++ b/.github/workflows/caro-ci.yml
@@ -62,19 +62,17 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
-
-      - name: Run tests
-        run: ./gradlew test
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
 
       - name: Generate Kover XML
-        run: ./gradlew koverAllXmlReport
+        run: ./gradlew koverAllXmlReport --build-cache --parallel
 
       - name: Collect Kover XML Report Paths
         id: report-paths
         run: |
-          echo "paths<<EOF" >> $GITHUB_OUTPUT
-          find . -path "*/build/reports/kover/report.xml" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          PATHS=$(find . -path "*/build/reports/kover/report.xml" -print0 | xargs -0 echo)
+          echo "paths=$PATHS" >> $GITHUB_OUTPUT
 
       - name: Comment coverage on PR
         uses: mi-kas/kover-report@v1.9

--- a/.github/workflows/caro-ci.yml
+++ b/.github/workflows/caro-ci.yml
@@ -82,6 +82,7 @@ jobs:
           title: ViewModel / Repository Test Coverage
           update-comment: true
           min-coverage-overall: 80
+          min-coverage-changed-files: 80
           coverage-counter-type: LINE
 
       - name: Slack Notify Coverage Result

--- a/.github/workflows/caro-ci.yml
+++ b/.github/workflows/caro-ci.yml
@@ -79,15 +79,14 @@ jobs:
         if: always()
         run: |
           echo "paths<<EOF" >> $GITHUB_OUTPUT
-          find . -path "*/build/reports/kover/**/report.xml" >> $GITHUB_OUTPUT
+          find . -path "*/build/reports/kover/report.xml" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Comment coverage on PR
         if: always()
         uses: mi-kas/kover-report@v1.9
         with:
-          path: |
-            ${{ steps.report-paths.outputs.paths }}
+          path: ${{ steps.report-paths.outputs.paths }}
           title: ViewModel / Repository Test Coverage
           update-comment: true
           min-coverage-overall: 80

--- a/.github/workflows/caro-ci.yml
+++ b/.github/workflows/caro-ci.yml
@@ -97,7 +97,7 @@ jobs:
           payload: |
             {
               "text": "${{ job.status == 'success'
-                && format('<{0}|#%s PR> 테스트 커버리지 통과 ✅', github.event.pull_request.html_url, github.event.pull_request.number)
-                || format('<{0}|#%s PR> 테스트 커버리지 미달 ❌', github.event.pull_request.html_url, github.event.pull_request.number)
+                && format('<{0}|PR #{1}> 테스트 커버리지 통과 ✅', github.event.pull_request.html_url, github.event.pull_request.number)
+                || format('<{0}|PR #{1}> 테스트 커버리지 미달 ❌', github.event.pull_request.html_url, github.event.pull_request.number)
               }}"
             }

--- a/.github/workflows/caro-ci.yml
+++ b/.github/workflows/caro-ci.yml
@@ -42,3 +42,45 @@ jobs:
                 || format('<{0}|#{1}> PR 린트 검사 결과 실패 🔥', github.event.pull_request.html_url, github.event.pull_request.number)
               }}"
             }
+
+  test-coverage:
+    name: Kover Test Coverage Measure
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Generate Kover XML
+        run: ./gradlew koverAllXmlReport
+
+      - name: Collect Kover XML Report Paths
+        id: report-paths
+        run: |
+          echo "paths<<EOF" >> $GITHUB_OUTPUT
+          find . -path "*/build/reports/kover/report.xml" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Comment coverage on PR
+        uses: mi-kas/kover-report@v1.9
+        with:
+          path: ${{ steps.report-paths.outputs.paths }}
+          title: ViewModel / Repository Test Coverage
+          update-comment: true
+          min-coverage-overall: 80
+          coverage-counter-type: LINE

--- a/.github/workflows/caro-ci.yml
+++ b/.github/workflows/caro-ci.yml
@@ -74,14 +74,19 @@ jobs:
       - name: Verify coverage
         run: ./gradlew koverAllVerify --build-cache --parallel
 
+      - name: Collect Kover XML Report Paths
+        id: report-paths
+        run: |
+          echo "paths<<EOF" >> $GITHUB_OUTPUT
+          find . -path "*/build/reports/kover/**/report.xml" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Comment coverage on PR
         if: always()
         uses: mi-kas/kover-report@v1.9
         with:
           path: |
-            core/data/build/reports/kover/report.xml
-            feature/login/build/reports/kover/report.xml
-            feature/home/build/reports/kover/report.xml
+            ${{ steps.report-paths.outputs.paths }}
           title: ViewModel / Repository Test Coverage
           update-comment: true
           min-coverage-overall: 80

--- a/.github/workflows/caro-ci.yml
+++ b/.github/workflows/caro-ci.yml
@@ -71,13 +71,15 @@ jobs:
       - name: Collect Kover XML Report Paths
         id: report-paths
         run: |
-          PATHS=$(find . -path "*/build/reports/kover/report.xml" -print0 | xargs -0 echo)
-          echo "paths=$PATHS" >> $GITHUB_OUTPUT
+          echo "paths<<EOF" >> $GITHUB_OUTPUT
+          find . -path "*/build/reports/kover/report.xml" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Comment coverage on PR
         uses: mi-kas/kover-report@v1.9
         with:
-          path: ${{ steps.report-paths.outputs.paths }}
+          path: |
+            ${{ steps.report-paths.outputs.paths }}
           title: ViewModel / Repository Test Coverage
           update-comment: true
           min-coverage-overall: 80

--- a/.github/workflows/caro-ci.yml
+++ b/.github/workflows/caro-ci.yml
@@ -65,6 +65,9 @@ jobs:
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
+      - name: Run test
+        run: ./gradlew test --build-cache --parallel
+
       - name: Generate Kover XML
         run: ./gradlew koverAllXmlReport --build-cache --parallel
 

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -71,5 +71,9 @@ gradlePlugin {
             id = "caro.koin"
             implementationClass = "KoinPlugin"
         }
+        register("koverPlugin") {
+            id = "caro.kover"
+            implementationClass = "KoverPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/KmpTestPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KmpTestPlugin.kt
@@ -12,7 +12,6 @@ class KmpTestPlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("dev.mokkery")
-                apply("org.jetbrains.kotlinx.kover")
                 apply("io.kotest")
             }
 

--- a/build-logic/convention/src/main/kotlin/KoverPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KoverPlugin.kt
@@ -1,0 +1,58 @@
+import com.whatever.caro.kover
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import kotlinx.kover.gradle.plugin.dsl.CoverageUnit
+import org.gradle.api.GradleException
+
+class KoverPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("org.jetbrains.kotlinx.kover")
+            }
+
+            val isDataModule = path == ":core:data"
+            val isFeatureModule = path.startsWith(":feature:")
+
+            if (!isDataModule && !isFeatureModule) {
+                throw GradleException(
+                    "caro.kover 플러그인은 ':core:data' 또는 ':feature:*' 모듈에서만 사용합니다. " +
+                            "현재 모듈 경로: $path"
+                )
+            }
+
+            kover {
+                reports {
+                    filters {
+                        excludes {
+                            packages("org.koin.ksp.generated.*")
+                            packages("*.ksp.*")
+                        }
+
+                        includes {
+                            when {
+                                path == ":core:data" -> classes("**RepositoryImpl*")
+                                path.startsWith(":feature:") -> classes("**ViewModel*")
+                            }
+                        }
+                    }
+
+                    verify {
+                        rule {
+                            bound {
+                                coverageUnits.set(CoverageUnit.LINE)
+                                minValue.set(COVERAGE_THRESHOLD)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val COVERAGE_THRESHOLD = 80
+    }
+
+}

--- a/build-logic/convention/src/main/kotlin/KoverPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KoverPlugin.kt
@@ -52,7 +52,7 @@ class KoverPlugin : Plugin<Project> {
     }
 
     companion object {
-        private const val COVERAGE_THRESHOLD = 80
+        private const val COVERAGE_THRESHOLD = 50 // TODO : 임시 50%로 설정 추후 80으로 변경
     }
 
 }

--- a/build-logic/convention/src/main/kotlin/com/whatever/caro/KoverGradleDsl.kt
+++ b/build-logic/convention/src/main/kotlin/com/whatever/caro/KoverGradleDsl.kt
@@ -1,0 +1,9 @@
+package com.whatever.caro
+
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+internal fun Project.kover(block: KoverProjectExtension.() -> Unit) {
+    extensions.configure(block)
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
     alias(libs.plugins.mokkery) apply false
     alias(libs.plugins.spotless) apply false
     alias(libs.plugins.kotest) apply false
+    alias(libs.plugins.kover) apply false
 }
 
 val ktlintCliVersion = libs.versions.ktlint.cli.get()
@@ -51,4 +52,34 @@ subprojects {
             eclipseWtp(EclipseWtpFormatterStep.XML)
         }
     }
+}
+
+/**
+ * Kover 적용된 모듈에 대한 XML 리포트 생성
+ * 터미널에서 ./gradlew koverAllXmlReport 를 실행
+ */
+tasks.register("koverAllXmlReport") {
+    group = "verification"
+    description = "Generate Kover XML reports for all coverage-enabled modules"
+
+    dependsOn(
+        ":feature:login:koverXmlReport",
+        ":feature:home:koverXmlReport",
+        ":core:data:koverXmlReport"
+    )
+}
+
+/**
+ * Kover 적용된 모듈에 대한 검증 실행
+ * 터미널에서 ./gradlew koverAllVerify 를 실행
+ */
+tasks.register("koverAllVerify") {
+    group = "verification"
+    description = "Verify Kover coverage for all coverage-enabled modules"
+
+    dependsOn(
+        ":feature:login:koverVerify",
+        ":feature:home:koverVerify",
+        ":core:data:koverVerify"
+    )
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("caro.kmp.android")
     id("caro.kmp.ios")
     id("caro.koin")
+    id("caro.kmp.test")
+    id("caro.kover")
 }
 
 kotlin {

--- a/core/data/src/commonTest/kotlin/DemoRepositoryTest.kt
+++ b/core/data/src/commonTest/kotlin/DemoRepositoryTest.kt
@@ -1,0 +1,71 @@
+import com.whatever.caro.core.data.di.RepositoryModule
+import com.whatever.caro.core.data.mapper.toUser
+import com.whatever.caro.core.data.repository.demo.DemoRepository
+import com.whatever.caro.core.remote.datasource.demo.DemoDataSource
+import com.whatever.caro.core.remote.di.NetworkModule
+import com.whatever.caro.core.remote.di.RemoteModule
+import com.whatever.caro.core.remote.model.DemoDto
+import com.whatever.caro.core.remote.model.demo.response.DemoResponse
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.koin.KoinExtension
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.koin.core.context.loadKoinModules
+import org.koin.core.context.unloadKoinModules
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.koin.ksp.generated.module
+import org.koin.test.KoinTest
+import org.koin.test.get
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DemoRepositoryImplKoinTest : FunSpec(), KoinTest {
+
+    private lateinit var overrideModule: Module
+
+    init {
+        extensions(
+            KoinExtension(
+                listOf(
+                    RepositoryModule().module,
+                    RemoteModule().module,
+                    NetworkModule().module,
+                )
+            )
+        )
+
+        test("getData - datasource 호출 + 매핑") {
+            runTest {
+                val demoDataSourceMock = mock<DemoDataSource>()
+
+                overrideModule = module {
+                    single<DemoDataSource> { demoDataSourceMock }
+                }
+
+                loadKoinModules(overrideModule)
+
+                everySuspend {
+                    demoDataSourceMock.getRestWithQuery(query = 123)
+                } returns DemoResponse(
+                    user = DemoDto(id = 123L, name = "테스터")
+                )
+
+                val repo: DemoRepository = get()
+
+                repo.getData(123L) shouldBe DemoResponse(
+                    user = DemoDto(id = 123L, name = "테스터")
+                ).toUser()
+            }
+        }
+
+        afterTest {
+            if (::overrideModule.isInitialized) {
+                unloadKoinModules(overrideModule)
+            }
+        }
+    }
+}

--- a/core/data/src/commonTest/kotlin/DemoRepositoryTest.kt
+++ b/core/data/src/commonTest/kotlin/DemoRepositoryTest.kt
@@ -23,8 +23,9 @@ import org.koin.test.KoinTest
 import org.koin.test.get
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class DemoRepositoryImplKoinTest : FunSpec(), KoinTest {
-
+class DemoRepositoryTest :
+    FunSpec(),
+    KoinTest {
     private lateinit var overrideModule: Module
 
     init {
@@ -34,31 +35,34 @@ class DemoRepositoryImplKoinTest : FunSpec(), KoinTest {
                     RepositoryModule().module,
                     RemoteModule().module,
                     NetworkModule().module,
-                )
-            )
+                ),
+            ),
         )
 
         test("getData - datasource 호출 + 매핑") {
             runTest {
                 val demoDataSourceMock = mock<DemoDataSource>()
 
-                overrideModule = module {
-                    single<DemoDataSource> { demoDataSourceMock }
-                }
+                overrideModule =
+                    module {
+                        single<DemoDataSource> { demoDataSourceMock }
+                    }
 
                 loadKoinModules(overrideModule)
 
                 everySuspend {
                     demoDataSourceMock.getRestWithQuery(query = 123)
-                } returns DemoResponse(
-                    user = DemoDto(id = 123L, name = "테스터")
-                )
+                } returns
+                    DemoResponse(
+                        user = DemoDto(id = 123L, name = "테스터"),
+                    )
 
                 val repo: DemoRepository = get()
 
-                repo.getData(123L) shouldBe DemoResponse(
-                    user = DemoDto(id = 123L, name = "테스터")
-                ).toUser()
+                repo.getData(123L) shouldBe
+                    DemoResponse(
+                        user = DemoDto(id = 123L, name = "테스터"),
+                    ).toUser()
             }
         }
 

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     id("caro.cmp")
     id("caro.feature")
     id("caro.koin")
+    id("caro.kmp.test")
+    id("caro.kover")
 }
 
 kotlin {

--- a/feature/home/src/commonTest/kotlin/HomeViewModelTest.kt
+++ b/feature/home/src/commonTest/kotlin/HomeViewModelTest.kt
@@ -29,8 +29,9 @@ import org.koin.test.KoinTest
 import org.koin.test.get
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class HomeViewModelTest : FunSpec(), KoinTest {
-
+class HomeViewModelTest :
+    FunSpec(),
+    KoinTest {
     private lateinit var overrideModule: Module
 
     init {
@@ -52,9 +53,10 @@ class HomeViewModelTest : FunSpec(), KoinTest {
             runTest {
                 val demoRepositoryMock = mock<DemoRepository>()
 
-                overrideModule = module {
-                    single<DemoRepository> { demoRepositoryMock }
-                }
+                overrideModule =
+                    module {
+                        single<DemoRepository> { demoRepositoryMock }
+                    }
                 loadKoinModules(overrideModule)
 
                 everySuspend { demoRepositoryMock.getData(1L) } returns User(1L, "건형")
@@ -65,10 +67,11 @@ class HomeViewModelTest : FunSpec(), KoinTest {
                 vm.init()
                 advanceUntilIdle()
 
-                vm.state.value shouldBe HomeState(
-                    screenName = "HomeScreen",
-                    name = "건형",
-                )
+                vm.state.value shouldBe
+                    HomeState(
+                        screenName = "HomeScreen",
+                        name = "건형",
+                    )
             }
         }
     }

--- a/feature/home/src/commonTest/kotlin/HomeViewModelTest.kt
+++ b/feature/home/src/commonTest/kotlin/HomeViewModelTest.kt
@@ -1,0 +1,75 @@
+import com.whatever.caro.core.data.repository.demo.DemoRepository
+import com.whatever.caro.core.model.User
+import com.whatever.caro.core.navigator.entries.HomeEntry
+import com.whatever.caro.core.navigator.entries.Payload
+import com.whatever.caro.feature.home.HomeViewModel
+import com.whatever.caro.feature.home.di.HomeModule
+import com.whatever.caro.feature.home.mvi.HomeState
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.koin.KoinExtension
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.koin.core.context.loadKoinModules
+import org.koin.core.context.unloadKoinModules
+import org.koin.core.module.Module
+import org.koin.core.parameter.parametersOf
+import org.koin.dsl.module
+import org.koin.ksp.generated.module
+import org.koin.test.KoinTest
+import org.koin.test.get
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest : FunSpec(), KoinTest {
+
+    private lateinit var overrideModule: Module
+
+    init {
+        extensions(KoinExtension(HomeModule().module))
+
+        val dispatcher = StandardTestDispatcher()
+
+        beforeTest {
+            Dispatchers.setMain(dispatcher)
+        }
+
+        afterTest {
+            unloadKoinModules(overrideModule)
+            Dispatchers.resetMain()
+            dispatcher.cancel()
+        }
+
+        test("init() 호출 시 state 갱신") {
+            runTest {
+                val demoRepositoryMock = mock<DemoRepository>()
+
+                overrideModule = module {
+                    single<DemoRepository> { demoRepositoryMock }
+                }
+                loadKoinModules(overrideModule)
+
+                everySuspend { demoRepositoryMock.getData(1L) } returns User(1L, "건형")
+
+                val navKey = HomeEntry(Payload(1, "테스터"))
+                val vm: HomeViewModel = get { parametersOf(navKey) }
+
+                vm.init()
+                advanceUntilIdle()
+
+                vm.state.value shouldBe HomeState(
+                    screenName = "HomeScreen",
+                    name = "건형",
+                )
+            }
+        }
+    }
+}

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("caro.feature")
     id("caro.koin")
     id("caro.kmp.test")
+    id("caro.kover")
 }
 
 kotlin {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ compose-stable-marker = "1.0.7"
 turbine = "1.2.1"
 mokkery = "3.1.1"
 kotest = "6.1.1"
-kover = "0.9.4"
+kover = "0.9.6"
 
 # Lint
 spotless = "8.2.1"
@@ -166,6 +166,7 @@ kotlin-serialization-gradleplugin = { group = "org.jetbrains.kotlin", name = "ko
 compose-compiler-gradleplugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
 compose-multiplatform-gradleplugin = { group = "org.jetbrains.compose", name = "compose-gradle-plugin", version.ref = "compose-multiplatform" }
 ksp-gradleplugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+kover-gradleplugin = { group = "org.jetbrains.kotlinx", name = "kover-gradle-plugin", version.ref = "kover" }
 
 [plugins]
 # Android
@@ -194,7 +195,6 @@ mokkery = { id = "dev.mokkery", version.ref = "mokkery" }
 spotless = { id = "com.diffplug.gradle.spotless", version.ref = "spotless" }
 kotest = { id = "io.kotest", version.ref = "kotest" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
-kover-aggregation = { id = "org.jetbrains.kotlinx.kover.aggregation", version.ref = "kover" }
 
 [bundles]
 ktor-client-plugin = [
@@ -222,5 +222,6 @@ build-logic-plugins = [
     "compose-compiler-gradleplugin",
     "compose-multiplatform-gradleplugin",
     "android-gradleplugin",
-    "ksp-gradleplugin"
+    "ksp-gradleplugin",
+    "kover-gradleplugin",
 ]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,10 +28,6 @@ dependencyResolutionManagement {
     }
 }
 
-plugins {
-    id("org.jetbrains.kotlinx.kover.aggregation") version "0.9.4"
-}
-
 rootProject.name = "CaroMobile"
 
 include(":androidApp")


### PR DESCRIPTION
## 관련 이슈
- closed #15 

## 작업한 내용
- KoverPlugin 구현
- `:feature` 모듈 Kover 플러그인 추가
- `:core:data` 모듈 Kover 플러그인 추가
- 테스트 커버리지 CI 구현

## PR 포인트
- 임계값 수치
  - 현재 커버리지 목표를 50으로 설정했습니다. 프로젝트 개발시 80으로 변경이 필요로 합니다. [dd67a1b](https://github.com/whatever-x/Caro-Mobile/pull/17/commits/dd67a1b7394ffe63a81ee5cb46f68299139360a2)
- 모듈별 플러그인으로 설정
  - aggregation 플러그인 대신 모듈별 플러그인 적용을 선택했습니다. 이유는 ViewModel과 Repository 가 포함된 모듈에 Kover 적용을 가시화 하기 위하여 선택했습니다. 운영해보면서 테스트 범위가 확장될 시 플러그인 수정 혹은 aggregation으로 Kover 설정이 필요할 때에 논의하면 좋을것 같습니다.
- 검증 및 Xml 리포트 생성 명령어
  ```
  # 커버리지 측정이 필요한 모듈 추가시 root build.gradle.kts에 모듈 추가

  # 검증 명령어
  ./gradlew koverAllVerify

  # Xml 리포트 생성 명령어
  ./gradlew koverAllXmlReport
  ```