### PR TITLE
[Refactor] Bot 코멘트 발생 시 Slack Notifier 차단

### DIFF
--- a/.github/workflows/slack-branch-notifier.yml
+++ b/.github/workflows/slack-branch-notifier.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   # ✅ 브랜치 생성
   notify-branch-created:
-    if: github.event.ref_type == 'branch' && github.event_name == 'create'
+    if: |
+      github.event.ref_type == 'branch' &&
+      github.event_name == 'create'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,7 +22,9 @@ jobs:
 
   # ✅ 브랜치 삭제
   notify-branch-deleted:
-    if: github.event.ref_type == 'branch' && github.event_name == 'delete'
+    if: |
+      github.event.ref_type == 'branch' &&
+      github.event_name == 'delete'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +34,9 @@ jobs:
 
   # ✅ 커밋 푸시
   notify-push-commit:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
+    if: |
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/heads/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/slack-comment-notifier.yml
+++ b/.github/workflows/slack-comment-notifier.yml
@@ -1,4 +1,4 @@
-name: Slack Notifier
+name: Slack Comment Notifier
 
 on:
   issue_comment:

--- a/.github/workflows/slack-comment-notifier.yml
+++ b/.github/workflows/slack-comment-notifier.yml
@@ -7,7 +7,11 @@ on:
 jobs:
   # ✅ 이슈 코멘트
   notify-issue-commented:
-    if: github.event_name == 'issue_comment' && github.event.action == 'created' && github.event.issue.pull_request == null
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.action == 'created' &&
+      github.event.issue.pull_request == null &&
+      github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,7 +21,11 @@ jobs:
 
   # ✅ PR 일반 코멘트
   notify-pr-general-commented:
-    if: github.event_name == 'issue_comment' && github.event.action == 'created' && github.event.issue.pull_request != null
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.action == 'created' &&
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/slack-issue-notifier.yml
+++ b/.github/workflows/slack-issue-notifier.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   # ✅ 이슈 생성 알림
   notify-issue-opened:
-    if: github.event_name == 'issues' && github.event.action == 'opened'
+    if: |
+      github.event_name == 'issues' &&
+      github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4
@@ -17,7 +19,9 @@ jobs:
 
   # ✅ 이슈 종료 알림
   notify-issue-closed:
-    if: github.event_name == 'issues' && github.event.action == 'closed'
+    if: |
+      github.event_name == 'issues' &&
+      github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/slack-pr-notifier.yml
+++ b/.github/workflows/slack-pr-notifier.yml
@@ -63,7 +63,11 @@ jobs:
 
   # ✅ PR 리뷰 코멘트
   notify-pr-review-commented:
-    if: github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.review.state == 'commented'
+    if: |
+      github.event_name == 'pull_request_review' &&
+      github.event.action == 'submitted' &&
+      github.event.review.state == 'commented' &&
+      github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +78,10 @@ jobs:
 
   # ✅ PR 라인 코멘트
   notify-pr-line-commented:
-    if: github.event_name == 'pull_request_review_comment' && github.event.action == 'created'
+    if: |
+      github.event_name == 'pull_request_review_comment' &&
+      github.event.action == 'created' &&
+      github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/slack-pr-notifier.yml
+++ b/.github/workflows/slack-pr-notifier.yml
@@ -11,7 +11,9 @@ on:
 jobs:
   # ✅ PR 생성 알림
   notify-pr-opened:
-    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +23,10 @@ jobs:
 
   # ✅ PR 병합 알림
   notify-pr-merged:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +36,10 @@ jobs:
 
   # ✅ PR 강제 종료 알림
   notify-pr-force-closed:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == false
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +49,10 @@ jobs:
 
   # ✅ PR 리뷰 승인
   notify-pr-review-approved:
-    if: github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.review.state == 'approved'
+    if: |
+      github.event_name == 'pull_request_review' &&
+      github.event.action == 'submitted' &&
+      github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +63,10 @@ jobs:
 
   # ✅ PR 리뷰 변경 요청
   notify-pr-review-changes:
-    if: github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.review.state == 'changes_requested'
+    if: |
+      github.event_name == 'pull_request_review' &&
+      github.event.action == 'submitted' &&
+      github.event.review.state == 'changes_requested'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/slack-pr-notifier.yml
+++ b/.github/workflows/slack-pr-notifier.yml
@@ -81,7 +81,7 @@ jobs:
       github.event_name == 'pull_request_review' &&
       github.event.action == 'submitted' &&
       github.event.review.state == 'commented' &&
-      github.event.comment.user.type != 'Bot'
+      github.event.review.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 관련 이슈
- closed #28 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 작업한 내용
- Slack 알림 워크플로우에서 봇 사용자 댓글 필터링 기능 추가
- GitHub Actions 워크플로우 if 조건을 단일 라인에서 다중 라인 형식으로 개선
- Slack Comment Notifier 워크플로우 이름 명확화
- 4개 워크플로우 파일 조건식 포맷 통일

## PR 포인트
### 봇 코멘트 차단 기능
- Issue 댓글 및 PR 댓글 작업에서 `github.event.comment.user.type != 'Bot'` 조건 추가
- PR 리뷰 코멘트 및 라인 코멘트 작업에서 동일한 봇 필터링 조건 적용
- 봇이 생성한 댓글로 인한 불필요한 Slack-notifier CI 실행 방지
- 리소스 낭비 제거 및 알림 신뢰도 향상

### 워크플로우 가독성 개선
- 복잡한 조건식을 YAML 블록 스칼라(pipe `|`)로 변환하여 여러 줄로 표현
- 논리적 조건의 기능은 유지하면서 가독성 및 유지보수성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->