### PR TITLE
[Feat] 네트워크 예외 핸들링

### DIFF
--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroClientException.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroClientException.kt
@@ -4,4 +4,5 @@ data class CaroClientException(
     override val code: String,
     override val message: String,
     override val debugMessage: String,
-) : CaroException(code, message, debugMessage)
+    override val throwable: Throwable? = null,
+) : CaroException(code, message, debugMessage, throwable)

--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroClientException.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroClientException.kt
@@ -1,0 +1,7 @@
+package com.whatever.caro.core.model.exception
+
+data class CaroClientException(
+    override val code: String,
+    override val message: String,
+    override val debugMessage: String,
+) : CaroException(code, message, debugMessage)

--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroException.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroException.kt
@@ -4,4 +4,5 @@ sealed class CaroException(
     open val code: String,
     override val message: String,
     open val debugMessage: String,
-) : Exception(message)
+    open val throwable: Throwable?,
+) : Exception(message, throwable)

--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroException.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroException.kt
@@ -1,0 +1,7 @@
+package com.whatever.caro.core.model.exception
+
+sealed class CaroException(
+    open val code: String,
+    override val message: String,
+    open val debugMessage: String,
+) : Exception(message)

--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroInvalidResponseException.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroInvalidResponseException.kt
@@ -1,0 +1,7 @@
+package com.whatever.caro.core.model.exception
+
+data class CaroInvalidResponseException(
+    override val code: String,
+    override val message: String,
+    override val debugMessage: String,
+) : CaroException(code, message, debugMessage)

--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroInvalidResponseException.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroInvalidResponseException.kt
@@ -4,4 +4,5 @@ data class CaroInvalidResponseException(
     override val code: String,
     override val message: String,
     override val debugMessage: String,
-) : CaroException(code, message, debugMessage)
+    override val throwable: Throwable? = null,
+) : CaroException(code, message, debugMessage, throwable)

--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroServerException.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroServerException.kt
@@ -1,0 +1,8 @@
+package com.whatever.caro.core.model.exception
+
+data class CaroServerException(
+    override val code: String,
+    override val message: String,
+    override val debugMessage: String,
+    val description: String? = null,
+) : CaroException(code, message, debugMessage)

--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroServerException.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/CaroServerException.kt
@@ -5,4 +5,5 @@ data class CaroServerException(
     override val message: String,
     override val debugMessage: String,
     val description: String? = null,
-) : CaroException(code, message, debugMessage)
+    override val throwable: Throwable? = null
+) : CaroException(code, message, debugMessage, throwable)

--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/ErrorCode.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/ErrorCode.kt
@@ -3,6 +3,7 @@ package com.whatever.caro.core.model.exception
 object ErrorCode {
     const val UNKNOWN = "UNKNOWN"
     const val INVALID_RESPONSE = "INVALID_RESPONSE"
+    const val CANCELLED = "CANCELLED"
     const val NETWORK_001 = "NETWORK_001"
     const val NETWORK_002 = "NETWORK_002"
 

--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/ErrorCode.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/ErrorCode.kt
@@ -1,0 +1,7 @@
+package com.whatever.caro.core.model.exception
+
+object ErrorCode {
+    const val UNKNOWN_001 = "UNKNOWN_001"
+
+    const val NETWORK_001 = "NETWORK_001"
+}

--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/ErrorCode.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/ErrorCode.kt
@@ -3,5 +3,8 @@ package com.whatever.caro.core.model.exception
 object ErrorCode {
     const val UNKNOWN_001 = "UNKNOWN_001"
 
+    const val INVALID_RESPONSE = "INVALID_RESPONSE"
     const val NETWORK_001 = "NETWORK_001"
+    const val NETWORK_002 = "NETWORK_002"
+
 }

--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/ErrorCode.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/ErrorCode.kt
@@ -1,8 +1,7 @@
 package com.whatever.caro.core.model.exception
 
 object ErrorCode {
-    const val UNKNOWN_001 = "UNKNOWN_001"
-
+    const val UNKNOWN = "UNKNOWN"
     const val INVALID_RESPONSE = "INVALID_RESPONSE"
     const val NETWORK_001 = "NETWORK_001"
     const val NETWORK_002 = "NETWORK_002"

--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/NetworkException.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/NetworkException.kt
@@ -1,0 +1,7 @@
+package com.whatever.caro.core.model.exception
+
+data class NetworkException(
+    override val code: String,
+    override val message: String,
+    override val debugMessage: String,
+) : CaroException(code, message, debugMessage)

--- a/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/NetworkException.kt
+++ b/core/model/src/commonMain/kotlin/com/whatever/caro/core/model/exception/NetworkException.kt
@@ -4,4 +4,5 @@ data class NetworkException(
     override val code: String,
     override val message: String,
     override val debugMessage: String,
-) : CaroException(code, message, debugMessage)
+    override val throwable: Throwable? = null
+) : CaroException(code, message, debugMessage, throwable)

--- a/core/remote/build.gradle.kts
+++ b/core/remote/build.gradle.kts
@@ -26,6 +26,8 @@ kotlin {
             implementation(libs.kotlinx.coroutines.android)
         }
         commonMain.dependencies {
+            implementation(projects.core.model)
+
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.serialization.kotlinx.json)
             implementation(libs.kotlinx.coroutines.core)

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/model/NetworkException.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/model/NetworkException.kt
@@ -1,8 +1,0 @@
-package com.whatever.caro.core.remote.model
-
-data class NetworkException(
-    val code: String,
-    override val message: String,
-    val debugMessage: String,
-    val description: String?,
-) : Exception(message)

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/HttpClientFactory.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/HttpClientFactory.kt
@@ -1,7 +1,7 @@
 package com.whatever.caro.core.remote.network
 
 import com.whatever.caro.core.remote.network.config.CaroNetworkConfig
-import com.whatever.caro.core.remote.network.plugins.CaroBaseResponseUnwrap
+import com.whatever.caro.core.remote.network.plugins.CaroBaseResponseConverter
 import com.whatever.caro.core.remote.network.plugins.installCaroResponseHandler
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
@@ -52,7 +52,7 @@ object HttpClientFactory {
                 installCaroResponseHandler(jsonParser)
             }
 
-            install(CaroBaseResponseUnwrap) {
+            install(CaroBaseResponseConverter) {
                 this.json = jsonParser
             }
 

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/HttpClientFactory.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/HttpClientFactory.kt
@@ -2,7 +2,7 @@ package com.whatever.caro.core.remote.network
 
 import com.whatever.caro.core.remote.network.config.CaroNetworkConfig
 import com.whatever.caro.core.remote.network.plugins.CaroBaseResponseConverter
-import com.whatever.caro.core.remote.network.plugins.installCaroResponseHandler
+import com.whatever.caro.core.remote.network.plugins.configureCaroExceptionMapping
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
@@ -49,7 +49,7 @@ object HttpClientFactory {
             }
 
             install(HttpCallValidator) {
-                installCaroResponseHandler(jsonParser)
+                configureCaroExceptionMapping(jsonParser)
             }
 
             install(CaroBaseResponseConverter) {

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/CaroBaseResponseConvertPlugin.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/CaroBaseResponseConvertPlugin.kt
@@ -1,8 +1,8 @@
 package com.whatever.caro.core.remote.network.plugins
 
-import com.whatever.caro.core.model.exception.CaroClientException
+import com.whatever.caro.core.model.exception.CaroInvalidResponseException
 import com.whatever.caro.core.model.exception.CaroServerException
-import com.whatever.caro.core.model.exception.ErrorCode.UNKNOWN_001
+import com.whatever.caro.core.model.exception.ErrorCode.INVALID_RESPONSE
 import com.whatever.caro.core.remote.model.CaroBaseResponse
 import io.ktor.client.plugins.api.ClientPlugin
 import io.ktor.client.plugins.api.createClientPlugin
@@ -34,19 +34,64 @@ internal val CaroBaseResponseConverter: ClientPlugin<CaroBaseResponseConverterCo
             val kotlinType = requestedType.kotlinType ?: return@transformResponseBody null
             val payloadText = content.readRemaining().readText(Charsets.UTF_8)
 
-            val requestedSerializer = json.serializersModule.serializer(kotlinType)
+            val requestedSerializer =
+                runCatching {
+                    json.serializersModule.serializer(kotlinType)
+                }.getOrElse { throwable ->
+                    throw CaroInvalidResponseException(
+                        code = INVALID_RESPONSE,
+                        message = "Invalid Response Error",
+                        debugMessage =
+                            buildDebugMessage(
+                                reason = "요청 타입에 대한 serializer를 찾지 못했습니다.",
+                                kotlinType = kotlinType,
+                                responseStatus = response.status.value,
+                                contentType = contentType,
+                                payloadText = payloadText,
+                                causeMessage = throwable.message,
+                            ),
+                    )
+                }
 
             val envelopeSerializer = CaroBaseResponse.serializer(requestedSerializer)
-            val baseResponse = json.decodeFromString(envelopeSerializer, payloadText)
+            val baseResponse =
+                runCatching {
+                    json.decodeFromString(envelopeSerializer, payloadText)
+                }.getOrElse { throwable ->
+                    throw CaroInvalidResponseException(
+                        code = INVALID_RESPONSE,
+                        message = "Invalid Response Error",
+                        debugMessage =
+                            buildDebugMessage(
+                                reason = "Response Body Decode 과정에서 실패 했습니다.",
+                                kotlinType = kotlinType,
+                                responseStatus = response.status.value,
+                                contentType = contentType,
+                                payloadText = payloadText,
+                                causeMessage = throwable.message,
+                            ),
+                    )
+                }
 
             if (!baseResponse.success) {
-                val error = baseResponse.error
+                val error = baseResponse.error ?: throw CaroInvalidResponseException(
+                    code = INVALID_RESPONSE,
+                    message = "Invalid Response Error",
+                    debugMessage =
+                        buildDebugMessage(
+                            reason = "success=false 이지만 error 페이로드가 null 입니다.",
+                            kotlinType = kotlinType,
+                            responseStatus = response.status.value,
+                            contentType = contentType,
+                            payloadText = payloadText,
+                        ),
+                )
 
                 throw CaroServerException(
-                    code = error?.code ?: UNKNOWN_001,
-                    message = error?.message ?: "Unknown Error",
-                    debugMessage = error?.debugMessage ?: "서버로부터 받은 debug 메세지가 비어있습니다.",
-                    description = error?.description,
+                    code = error.code,
+                    message = error.message,
+                    debugMessage = error.debugMessage ?: "서버로부터 받은 debug 메세지가 비어있습니다.",
+                    description = error.description,
                 )
             }
 
@@ -60,21 +105,42 @@ internal val CaroBaseResponseConverter: ClientPlugin<CaroBaseResponseConverterCo
                 return@transformResponseBody Unit
             }
 
-            throw CaroClientException(
-                code = UNKNOWN_001,
-                message = "Unknown Error",
+            throw CaroInvalidResponseException(
+                code = INVALID_RESPONSE,
+                message = "Invalid Response Error",
                 debugMessage =
-                    buildString {
-                        append("Response unwrap failed: expected non-null data but got null")
-                        append(", requestedType=")
-                        append(kotlinType)
-                        append(", responseStatus=")
-                        append(response.status.value)
-                        append(", contentType=")
-                        append(contentType)
-                        append(", payloadPreview=")
-                        append(payloadText.take(300))
-                    },
+                    buildDebugMessage(
+                        reason = "success=true 이지만 non-Unit 응답의 data가 null입니다",
+                        kotlinType = kotlinType,
+                        responseStatus = response.status.value,
+                        contentType = contentType,
+                        payloadText = payloadText,
+                    ),
             )
         }
+    }
+
+private fun buildDebugMessage(
+    reason: String,
+    kotlinType: Any,
+    responseStatus: Int,
+    contentType: ContentType?,
+    payloadText: String,
+    causeMessage: String? = null,
+): String =
+    buildString {
+        append("Response Converter failed: ")
+        append(reason)
+        append(", requestedType=")
+        append(kotlinType)
+        append(", responseStatus=")
+        append(responseStatus)
+        append(", contentType=")
+        append(contentType ?: "unknown")
+        if (!causeMessage.isNullOrBlank()) {
+            append(", cause=")
+            append(causeMessage)
+        }
+        append(", payloadPreview=")
+        append(payloadText.take(300))
     }

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/CaroBaseResponseConvertPlugin.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/CaroBaseResponseConvertPlugin.kt
@@ -50,6 +50,7 @@ internal val CaroBaseResponseConverter: ClientPlugin<CaroBaseResponseConverterCo
                                 payloadText = payloadText,
                                 causeMessage = throwable.message,
                             ),
+                        throwable = throwable,
                     )
                 }
 
@@ -70,6 +71,7 @@ internal val CaroBaseResponseConverter: ClientPlugin<CaroBaseResponseConverterCo
                                 payloadText = payloadText,
                                 causeMessage = throwable.message,
                             ),
+                        throwable = throwable,
                     )
                 }
 

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/CaroBaseResponseConvertPlugin.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/CaroBaseResponseConvertPlugin.kt
@@ -14,14 +14,14 @@ import io.ktor.utils.io.readRemaining
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 
-internal class CaroBaseResponseUnwrapConfig {
+internal class CaroBaseResponseConverterConfig {
     lateinit var json: Json
 }
 
-internal val CaroBaseResponseUnwrap: ClientPlugin<CaroBaseResponseUnwrapConfig> =
+internal val CaroBaseResponseConverter: ClientPlugin<CaroBaseResponseConverterConfig> =
     createClientPlugin(
-        name = "CaroBaseResponseUnwrap",
-        createConfiguration = ::CaroBaseResponseUnwrapConfig,
+        name = "CaroBaseResponseConverter",
+        createConfiguration = ::CaroBaseResponseConverterConfig,
     ) {
         val json: Json = pluginConfig.json
 

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/CaroBaseResponseConvertPlugin.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/CaroBaseResponseConvertPlugin.kt
@@ -43,7 +43,7 @@ internal val CaroBaseResponseConverter: ClientPlugin<CaroBaseResponseConverterCo
                 val error = baseResponse.error
 
                 throw CaroServerException(
-                    code = error?.code ?: "9999",
+                    code = error?.code ?: UNKNOWN_001,
                     message = error?.message ?: "Unknown Error",
                     debugMessage = error?.debugMessage ?: "서버로부터 받은 debug 메세지가 비어있습니다.",
                     description = error?.description,

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/CaroBaseResponseUnwrapPlugin.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/CaroBaseResponseUnwrapPlugin.kt
@@ -1,7 +1,9 @@
 package com.whatever.caro.core.remote.network.plugins
 
+import com.whatever.caro.core.model.exception.CaroClientException
+import com.whatever.caro.core.model.exception.CaroServerException
+import com.whatever.caro.core.model.exception.ErrorCode.UNKNOWN_001
 import com.whatever.caro.core.remote.model.CaroBaseResponse
-import com.whatever.caro.core.remote.model.NetworkException
 import io.ktor.client.plugins.api.ClientPlugin
 import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.http.ContentType
@@ -40,10 +42,10 @@ internal val CaroBaseResponseUnwrap: ClientPlugin<CaroBaseResponseUnwrapConfig> 
             if (!baseResponse.success) {
                 val error = baseResponse.error
 
-                throw NetworkException(
-                    code = error?.code ?: "Unknown",
+                throw CaroServerException(
+                    code = error?.code ?: "9999",
                     message = error?.message ?: "Unknown Error",
-                    debugMessage = error?.debugMessage ?: "Unknown Error",
+                    debugMessage = error?.debugMessage ?: "서버로부터 받은 debug 메세지가 비어있습니다.",
                     description = error?.description,
                 )
             }
@@ -58,11 +60,21 @@ internal val CaroBaseResponseUnwrap: ClientPlugin<CaroBaseResponseUnwrapConfig> 
                 return@transformResponseBody Unit
             }
 
-            throw NetworkException(
-                code = "Unknown",
-                message = "예상치 못한 에러가 발생했습니다.",
-                debugMessage = "Data is null",
-                description = null,
+            throw CaroClientException(
+                code = UNKNOWN_001,
+                message = "Unknown Error",
+                debugMessage =
+                    buildString {
+                        append("Response unwrap failed: expected non-null data but got null")
+                        append(", requestedType=")
+                        append(kotlinType)
+                        append(", responseStatus=")
+                        append(response.status.value)
+                        append(", contentType=")
+                        append(contentType)
+                        append(", payloadPreview=")
+                        append(payloadText.take(300))
+                    },
             )
         }
     }

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/CaroResponseHandler.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/CaroResponseHandler.kt
@@ -1,34 +1,65 @@
 package com.whatever.caro.core.remote.network.plugins
 
+import com.whatever.caro.core.model.exception.CaroServerException
+import com.whatever.caro.core.model.exception.ErrorCode.NETWORK_001
+import com.whatever.caro.core.model.exception.ErrorCode.UNKNOWN_001
+import com.whatever.caro.core.model.exception.NetworkException
 import com.whatever.caro.core.remote.model.CaroBaseResponse
-import com.whatever.caro.core.remote.model.NetworkException
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpCallValidatorConfig
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.statement.bodyAsText
+import io.ktor.util.network.UnresolvedAddressException
+import kotlinx.io.IOException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
 internal fun HttpCallValidatorConfig.installCaroResponseHandler(jsonParser: Json) {
     handleResponseExceptionWithRequest { cause, _ ->
-        val responseException =
-            cause as? ResponseException ?: return@handleResponseExceptionWithRequest
+        val serverResponseException = cause as? ResponseException
+        if (serverResponseException != null) {
+            val baseResponse =
+                runCatching {
+                    jsonParser.decodeFromString<CaroBaseResponse<JsonElement>>(
+                        serverResponseException.response.bodyAsText(),
+                    )
+                }.getOrNull()
 
-        val baseResponse =
-            runCatching {
-                jsonParser.decodeFromString<CaroBaseResponse<JsonElement>>(
-                    responseException.response.bodyAsText(),
+            val errorResponse = baseResponse?.error
+
+            throw CaroServerException(
+                code =
+                    errorResponse?.code ?: serverResponseException.response.status.value
+                        .toString(),
+                message = errorResponse?.message ?: "Caro Server error",
+                debugMessage = errorResponse?.debugMessage ?: "Caro Server error",
+                description = errorResponse?.description,
+            )
+        }
+
+        throw when (cause) {
+            is HttpRequestTimeoutException,
+            is ConnectTimeoutException,
+            is SocketTimeoutException,
+            is UnresolvedAddressException,
+            is IOException,
+                -> {
+                NetworkException(
+                    code = NETWORK_001,
+                    message = "Network Error",
+                    debugMessage = "네트워크 오류 발생\n원인 : ${cause.message}",
                 )
-            }.getOrNull()
+            }
 
-        val errorResponse = baseResponse?.error
-
-        throw NetworkException(
-            code =
-                errorResponse?.code ?: responseException.response.status.value
-                    .toString(),
-            message = errorResponse?.message ?: "Server error",
-            debugMessage = errorResponse?.debugMessage ?: cause.message.orEmpty(),
-            description = errorResponse?.description,
-        )
+            else -> {
+                NetworkException(
+                    code = UNKNOWN_001,
+                    message = "Unknown Error",
+                    debugMessage = "알 수 없는 오류 발생\n원인 : ${cause.message}",
+                )
+            }
+        }
     }
 }

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/ConfigureCaroExceptionMapping.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/ConfigureCaroExceptionMapping.kt
@@ -1,8 +1,12 @@
 package com.whatever.caro.core.remote.network.plugins
 
+import com.whatever.caro.core.model.exception.CaroClientException
+import com.whatever.caro.core.model.exception.CaroInvalidResponseException
 import com.whatever.caro.core.model.exception.CaroServerException
+import com.whatever.caro.core.model.exception.ErrorCode.INVALID_RESPONSE
 import com.whatever.caro.core.model.exception.ErrorCode.NETWORK_001
-import com.whatever.caro.core.model.exception.ErrorCode.UNKNOWN_001
+import com.whatever.caro.core.model.exception.ErrorCode.NETWORK_002
+import com.whatever.caro.core.model.exception.ErrorCode.UNKNOWN
 import com.whatever.caro.core.model.exception.NetworkException
 import com.whatever.caro.core.remote.model.CaroBaseResponse
 import io.ktor.client.network.sockets.ConnectTimeoutException
@@ -12,6 +16,7 @@ import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.statement.bodyAsText
 import io.ktor.util.network.UnresolvedAddressException
+import kotlinx.coroutines.CancellationException
 import kotlinx.io.IOException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -20,46 +25,113 @@ internal fun HttpCallValidatorConfig.configureCaroExceptionMapping(jsonParser: J
     handleResponseExceptionWithRequest { cause, _ ->
         val serverResponseException = cause as? ResponseException
         if (serverResponseException != null) {
+            val response = serverResponseException.response
+            val responseText =
+                runCatching {
+                    response.bodyAsText()
+                }.getOrElse { throwable ->
+                    throw CaroInvalidResponseException(
+                        code = INVALID_RESPONSE,
+                        message = "Invalid Response Error",
+                        debugMessage =
+                            buildResponseDebugMessage(
+                                reason = "Response Body를 읽는 것을 실패 했습니다.",
+                                statusCode = response.status.value,
+                                causeMessage = throwable.message,
+                            ),
+                    )
+                }
+
             val baseResponse =
                 runCatching {
-                    jsonParser.decodeFromString<CaroBaseResponse<JsonElement>>(
-                        serverResponseException.response.bodyAsText(),
+                    jsonParser.decodeFromString<CaroBaseResponse<JsonElement>>(responseText)
+                }.getOrElse { throwable ->
+                    throw CaroInvalidResponseException(
+                        code = INVALID_RESPONSE,
+                        message = "Invalid Response Error",
+                        debugMessage =
+                            buildResponseDebugMessage(
+                                reason = "Response Body Decode 과정에서 실패 했습니다.",
+                                statusCode = response.status.value,
+                                payloadText = responseText,
+                                causeMessage = throwable.message,
+                            ),
                     )
-                }.getOrNull()
+                }
 
-            val errorResponse = baseResponse?.error
+            val errorResponse = baseResponse.error ?: throw CaroInvalidResponseException(
+                code = INVALID_RESPONSE,
+                message = "Invalid Response Error",
+                debugMessage =
+                    buildResponseDebugMessage(
+                        reason = "Error Response가 null 입니다.",
+                        statusCode = response.status.value,
+                        payloadText = responseText,
+                    ),
+            )
 
             throw CaroServerException(
-                code =
-                    errorResponse?.code ?: serverResponseException.response.status.value
-                        .toString(),
-                message = errorResponse?.message ?: "Caro Server error",
-                debugMessage = errorResponse?.debugMessage ?: "Caro Server error",
-                description = errorResponse?.description,
+                code = errorResponse.code,
+                message = errorResponse.message,
+                debugMessage = errorResponse.debugMessage ?: "서버로부터 받은 debug 메세지가 비어있습니다.",
+                description = errorResponse.description,
             )
         }
 
         throw when (cause) {
+            is CancellationException -> {
+                cause
+            }
+
             is HttpRequestTimeoutException,
             is ConnectTimeoutException,
             is SocketTimeoutException,
+            -> {
+                NetworkException(
+                    code = NETWORK_002,
+                    message = "Network Timeout Error",
+                    debugMessage = "네트워크 타임아웃 발생: ${cause.message.orEmpty()}",
+                )
+            }
+
             is UnresolvedAddressException,
             is IOException,
-                -> {
+            -> {
                 NetworkException(
                     code = NETWORK_001,
                     message = "Network Error",
-                    debugMessage = "네트워크 오류 발생\n원인 : ${cause.message}",
+                    debugMessage = "네트워크 연결 오류 발생: ${cause.message.orEmpty()}",
                 )
             }
 
             else -> {
-                NetworkException(
-                    code = UNKNOWN_001,
+                CaroClientException(
+                    code = UNKNOWN,
                     message = "Unknown Error",
-                    debugMessage = "알 수 없는 오류 발생\n원인 : ${cause.message}",
+                    debugMessage = "알 수 없는 예외가 발생했습니다. cause=${cause.message.orEmpty()}",
                 )
             }
         }
     }
 }
+
+private fun buildResponseDebugMessage(
+    reason: String,
+    statusCode: Int,
+    payloadText: String? = null,
+    causeMessage: String? = null,
+): String =
+    buildString {
+        append("Response exception mapping 실패 : ")
+        append(reason)
+        append(", statusCode=")
+        append(statusCode)
+        if (!causeMessage.isNullOrBlank()) {
+            append(", cause=")
+            append(causeMessage)
+        }
+        if (payloadText != null) {
+            append(", payloadPreview=")
+            append(payloadText.take(300))
+        }
+    }

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/ConfigureCaroExceptionMapping.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/ConfigureCaroExceptionMapping.kt
@@ -83,12 +83,7 @@ internal fun HttpCallValidatorConfig.configureCaroExceptionMapping(jsonParser: J
 
         throw when (cause) {
             is CancellationException -> {
-                CaroClientException(
-                    code = CANCELLED,
-                    message = "Network Request Cancelled",
-                    debugMessage = "네트워크 요청이 취소되었습니다. cause=${cause.message.orEmpty()}",
-                    throwable = cause,
-                )
+                cause
             }
 
             is HttpRequestTimeoutException,

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/ConfigureCaroExceptionMapping.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/ConfigureCaroExceptionMapping.kt
@@ -39,6 +39,7 @@ internal fun HttpCallValidatorConfig.configureCaroExceptionMapping(jsonParser: J
                                 statusCode = response.status.value,
                                 causeMessage = throwable.message,
                             ),
+                        throwable = throwable,
                     )
                 }
 
@@ -56,6 +57,7 @@ internal fun HttpCallValidatorConfig.configureCaroExceptionMapping(jsonParser: J
                                 payloadText = responseText,
                                 causeMessage = throwable.message,
                             ),
+                        throwable = throwable,
                     )
                 }
 
@@ -91,6 +93,7 @@ internal fun HttpCallValidatorConfig.configureCaroExceptionMapping(jsonParser: J
                     code = NETWORK_002,
                     message = "Network Timeout Error",
                     debugMessage = "네트워크 타임아웃 발생: ${cause.message.orEmpty()}",
+                    throwable = cause,
                 )
             }
 
@@ -101,6 +104,7 @@ internal fun HttpCallValidatorConfig.configureCaroExceptionMapping(jsonParser: J
                     code = NETWORK_001,
                     message = "Network Error",
                     debugMessage = "네트워크 연결 오류 발생: ${cause.message.orEmpty()}",
+                    throwable = cause,
                 )
             }
 
@@ -109,6 +113,7 @@ internal fun HttpCallValidatorConfig.configureCaroExceptionMapping(jsonParser: J
                     code = UNKNOWN,
                     message = "Unknown Error",
                     debugMessage = "알 수 없는 예외가 발생했습니다. cause=${cause.message.orEmpty()}",
+                    throwable = cause,
                 )
             }
         }

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/ConfigureCaroExceptionMapping.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/ConfigureCaroExceptionMapping.kt
@@ -16,7 +16,7 @@ import kotlinx.io.IOException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
-internal fun HttpCallValidatorConfig.installCaroResponseHandler(jsonParser: Json) {
+internal fun HttpCallValidatorConfig.configureCaroExceptionMapping(jsonParser: Json) {
     handleResponseExceptionWithRequest { cause, _ ->
         val serverResponseException = cause as? ResponseException
         if (serverResponseException != null) {

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/ConfigureCaroExceptionMapping.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/network/plugins/ConfigureCaroExceptionMapping.kt
@@ -3,6 +3,7 @@ package com.whatever.caro.core.remote.network.plugins
 import com.whatever.caro.core.model.exception.CaroClientException
 import com.whatever.caro.core.model.exception.CaroInvalidResponseException
 import com.whatever.caro.core.model.exception.CaroServerException
+import com.whatever.caro.core.model.exception.ErrorCode.CANCELLED
 import com.whatever.caro.core.model.exception.ErrorCode.INVALID_RESPONSE
 import com.whatever.caro.core.model.exception.ErrorCode.NETWORK_001
 import com.whatever.caro.core.model.exception.ErrorCode.NETWORK_002
@@ -82,7 +83,12 @@ internal fun HttpCallValidatorConfig.configureCaroExceptionMapping(jsonParser: J
 
         throw when (cause) {
             is CancellationException -> {
-                cause
+                CaroClientException(
+                    code = CANCELLED,
+                    message = "Network Request Cancelled",
+                    debugMessage = "네트워크 요청이 취소되었습니다. cause=${cause.message.orEmpty()}",
+                    throwable = cause,
+                )
             }
 
             is HttpRequestTimeoutException,

--- a/core/remote/src/commonTest/kotlin/com/whatever/caro/core/test/module/NetworkModuleTest.kt
+++ b/core/remote/src/commonTest/kotlin/com/whatever/caro/core/test/module/NetworkModuleTest.kt
@@ -2,7 +2,7 @@ package com.whatever.caro.core.test.module
 
 import com.whatever.caro.core.remote.di.networkModule
 import com.whatever.caro.core.remote.di.qualifier.NetworkClient
-import com.whatever.caro.core.remote.network.plugins.CaroBaseResponseUnwrap
+import com.whatever.caro.core.remote.network.plugins.CaroBaseResponseConverter
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.koin.KoinExtension
@@ -47,7 +47,7 @@ class NetworkModuleTest :
             shouldNotThrowAny { authClient.plugin(HttpTimeout) }
             shouldNotThrowAny { authClient.plugin(Logging) }
             shouldNotThrowAny { authClient.plugin(HttpCallValidator) }
-            shouldNotThrowAny { authClient.plugin(CaroBaseResponseUnwrap) }
+            shouldNotThrowAny { authClient.plugin(CaroBaseResponseConverter) }
         }
 
         test("Caro NON_AUTH 클라이언트는 공통 네트워크 플러그인을 install 해야한다.") {
@@ -57,7 +57,7 @@ class NetworkModuleTest :
             shouldNotThrowAny { nonAuthClient.plugin(HttpTimeout) }
             shouldNotThrowAny { nonAuthClient.plugin(Logging) }
             shouldNotThrowAny { nonAuthClient.plugin(HttpCallValidator) }
-            shouldNotThrowAny { nonAuthClient.plugin(CaroBaseResponseUnwrap) }
+            shouldNotThrowAny { nonAuthClient.plugin(CaroBaseResponseConverter) }
         }
 
         test("networkModule은 공통 Json 설정을 제공한다.") {

--- a/core/remote/src/commonTest/kotlin/com/whatever/caro/core/test/plugin/CaroBaseResponseConverterTest.kt
+++ b/core/remote/src/commonTest/kotlin/com/whatever/caro/core/test/plugin/CaroBaseResponseConverterTest.kt
@@ -1,0 +1,183 @@
+package com.whatever.caro.core.test.plugin
+
+import com.whatever.caro.core.model.exception.CaroClientException
+import com.whatever.caro.core.model.exception.CaroServerException
+import com.whatever.caro.core.model.exception.ErrorCode
+import com.whatever.caro.core.remote.model.demo.DemoDto
+import com.whatever.caro.core.remote.model.demo.response.DemoResponse
+import com.whatever.caro.core.remote.network.plugins.CaroBaseResponseConverter
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+class CaroBaseResponseConverterTest : FunSpec() {
+    init {
+        test("success=true 이면 data payload 를 요청 타입으로 언랩한다") {
+            val client =
+                createClient(
+                    responseBody =
+                        """
+                        {
+                          "success": true,
+                          "data": {
+                            "user": {
+                              "id": 1,
+                              "name": "caro"
+                            }
+                          },
+                          "error": null
+                        }
+                        """.trimIndent(),
+                )
+
+            val body = shouldNotThrowAny { client.get("https://caro.test/demo").body<DemoResponse>() }
+
+            body shouldBe DemoResponse(user = DemoDto(id = 1, name = "caro"))
+        }
+
+        test("success=true 이고 data=null 일 때 Unit 요청은 성공 처리한다") {
+            val client =
+                createClient(
+                    responseBody =
+                        """
+                        {
+                          "success": true,
+                          "data": null,
+                          "error": null
+                        }
+                        """.trimIndent(),
+                )
+
+            shouldNotThrowAny {
+                client.get("https://caro.test/demo").body<Unit>() shouldBe Unit
+            }
+        }
+
+        test("success=false 이면 200 응답이어도 CaroServerException 을 던진다") {
+            val client =
+                createClient(
+                    responseBody =
+                        """
+                        {
+                          "success": false,
+                          "data": null,
+                          "error": {
+                            "code": "AUTH-401",
+                            "message": "사용자 토큰 인증에 실패했습니다.",
+                            "debugMessage": "사용자 토큰 인증 실패",
+                            "description": "login again"
+                          }
+                        }
+                        """.trimIndent(),
+                )
+
+            val exception =
+                shouldThrow<CaroServerException> {
+                    client.get("https://caro.test/demo").body<DemoResponse>()
+                }
+
+            exception.code shouldBe "AUTH-401"
+            exception.message shouldBe "사용자 토큰 인증에 실패했습니다."
+            exception.debugMessage shouldBe "사용자 토큰 인증 실패"
+            exception.description shouldBe "login again"
+        }
+
+        test("success=false 인데 error 가 없으면 code가 UNKNOWN_001인 CaroServerException 예외를 던진다") {
+            val client =
+                createClient(
+                    responseBody =
+                        """
+                        {
+                          "success": false,
+                          "data": null,
+                          "error": null
+                        }
+                        """.trimIndent(),
+                )
+
+            val exception =
+                shouldThrow<CaroServerException> {
+                    client.get("https://caro.test/demo").body<DemoResponse>()
+                }
+
+            exception.code shouldBe ErrorCode.UNKNOWN_001
+            exception.debugMessage shouldBe "서버로부터 받은 debug 메세지가 비어있습니다."
+        }
+
+        test("success=true 인데 data=null 이면 code가 UNKNOWN_001인 CaroClientException 예외를 던진다") {
+            val client =
+                createClient(
+                    responseBody =
+                        """
+                        {
+                          "success": true,
+                          "data": null,
+                          "error": null
+                        }
+                        """.trimIndent(),
+                )
+
+            val exception =
+                shouldThrow<CaroClientException> {
+                    client.get("https://caro.test/demo").body<DemoResponse>()
+                }
+
+            exception.code shouldBe ErrorCode.UNKNOWN_001
+        }
+
+        test("JSON 이 아닌 응답은 unwrap 하지 않고 그대로 전달한다") {
+            val client =
+                createClient(
+                    responseBody = "plain-text",
+                    contentType = ContentType.Text.Plain,
+                )
+
+            shouldNotThrowAny {
+                client.get("https://caro.test/demo").body<String>() shouldBe "plain-text"
+            }
+        }
+    }
+
+    companion object {
+        private val jsonParser =
+            Json {
+                ignoreUnknownKeys = true
+                prettyPrint = true
+            }
+
+        private fun createClient(
+            responseBody: String,
+            contentType: ContentType = ContentType.Application.Json,
+        ): HttpClient =
+            HttpClient(
+                MockEngine {
+                    respond(
+                        content = responseBody,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, contentType.toString()),
+                    )
+                },
+            ) {
+                install(CaroBaseResponseConverter) {
+                    this.json = jsonParser
+                }
+
+                install(ContentNegotiation) {
+                    json(jsonParser)
+                }
+            }
+    }
+}

--- a/core/remote/src/commonTest/kotlin/com/whatever/caro/core/test/plugin/CaroBaseResponseConverterTest.kt
+++ b/core/remote/src/commonTest/kotlin/com/whatever/caro/core/test/plugin/CaroBaseResponseConverterTest.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.core.test.plugin
 
-import com.whatever.caro.core.model.exception.CaroClientException
+import com.whatever.caro.core.model.exception.CaroInvalidResponseException
 import com.whatever.caro.core.model.exception.CaroServerException
 import com.whatever.caro.core.model.exception.ErrorCode
 import com.whatever.caro.core.remote.model.demo.DemoDto
@@ -25,7 +25,7 @@ import kotlinx.serialization.json.Json
 
 class CaroBaseResponseConverterTest : FunSpec() {
     init {
-        test("success=true 이면 data payload 를 요청 타입으로 언랩한다") {
+        test("success=true 이면 data payload 를 요청 타입으로 변환한다") {
             val client =
                 createClient(
                     responseBody =
@@ -95,7 +95,7 @@ class CaroBaseResponseConverterTest : FunSpec() {
             exception.description shouldBe "login again"
         }
 
-        test("success=false 인데 error 가 없으면 code가 UNKNOWN_001인 CaroServerException 예외를 던진다") {
+        test("success=false 인데 error 가 없으면 INVALID_RESPONSE인 CaroInvalidResponseException 예외를 던진다") {
             val client =
                 createClient(
                     responseBody =
@@ -109,15 +109,15 @@ class CaroBaseResponseConverterTest : FunSpec() {
                 )
 
             val exception =
-                shouldThrow<CaroServerException> {
+                shouldThrow<CaroInvalidResponseException> {
                     client.get("https://caro.test/demo").body<DemoResponse>()
                 }
 
-            exception.code shouldBe ErrorCode.UNKNOWN_001
-            exception.debugMessage shouldBe "서버로부터 받은 debug 메세지가 비어있습니다."
+            exception.code shouldBe ErrorCode.INVALID_RESPONSE
+            exception.message shouldBe "Invalid Response Error"
         }
 
-        test("success=true 인데 data=null 이면 code가 UNKNOWN_001인 CaroClientException 예외를 던진다") {
+        test("success=true 인데 data=null 이면 INVALID_RESPONSE인 CaroInvalidResponseException 예외를 던진다") {
             val client =
                 createClient(
                     responseBody =
@@ -131,14 +131,37 @@ class CaroBaseResponseConverterTest : FunSpec() {
                 )
 
             val exception =
-                shouldThrow<CaroClientException> {
+                shouldThrow<CaroInvalidResponseException> {
                     client.get("https://caro.test/demo").body<DemoResponse>()
                 }
 
-            exception.code shouldBe ErrorCode.UNKNOWN_001
+            exception.code shouldBe ErrorCode.INVALID_RESPONSE
+            exception.message shouldBe "Invalid Response Error"
         }
 
-        test("JSON 이 아닌 응답은 unwrap 하지 않고 그대로 전달한다") {
+        test("응답 decode에 실패하면 INVALID_RESPONSE인 CaroInvalidResponseException 예외를 던진다") {
+            val client =
+                createClient(
+                    responseBody =
+                        """
+                        {
+                          "success": true,
+                          "data": "invalid-shape",
+                          "error": null
+                        }
+                        """.trimIndent(),
+                )
+
+            val exception =
+                shouldThrow<CaroInvalidResponseException> {
+                    client.get("https://caro.test/demo").body<DemoResponse>()
+                }
+
+            exception.code shouldBe ErrorCode.INVALID_RESPONSE
+            exception.message shouldBe "Invalid Response Error"
+        }
+
+        test("JSON 이 아닌 응답이면 converter가 개입하지 않는다") {
             val client =
                 createClient(
                     responseBody = "plain-text",

--- a/core/remote/src/commonTest/kotlin/com/whatever/caro/core/test/plugin/ConfigureCaroExceptionMappingTest.kt
+++ b/core/remote/src/commonTest/kotlin/com/whatever/caro/core/test/plugin/ConfigureCaroExceptionMappingTest.kt
@@ -1,8 +1,7 @@
 package com.whatever.caro.core.test.plugin
 
-import com.whatever.caro.core.remote.model.NetworkException
-import com.whatever.caro.core.remote.network.plugins.CaroBaseResponseUnwrap
-import com.whatever.caro.core.remote.network.plugins.installCaroResponseHandler
+import com.whatever.caro.core.model.exception.CaroServerException
+import com.whatever.caro.core.remote.network.plugins.configureCaroExceptionMapping
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
@@ -21,42 +20,13 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
-class CaroResponseHandlerTest : FunSpec() {
+class ConfigureCaroExceptionMappingTest : FunSpec() {
     init {
-        test("에러 응답의 Caro error body를 NetworkException으로 변환한다") {
+        test("InternalServerError 발생시 Caro error body를 CaroServerException으로 변환한다") {
+            val errorStatus = HttpStatusCode.InternalServerError
             val client =
                 createClient(
-                    status = HttpStatusCode.InternalServerError,
-                    responseBody =
-                        """
-                        {
-                          "success": false,
-                          "data": { },
-                          "error": {
-                            "code": "SERVER-500",
-                            "message": "server exploded",
-                            "debugMessage": "stacktrace",
-                            "description": "retry later"
-                          }
-                        }
-                        """.trimIndent(),
-                )
-
-            val exception =
-                shouldThrow<NetworkException> {
-                    client.get("https://caro.test/sample").body<String>()
-                }
-
-            exception.code shouldBe "SERVER-500"
-            exception.message shouldBe "server exploded"
-            exception.debugMessage shouldBe "stacktrace"
-            exception.description shouldBe "retry later"
-        }
-
-        test("unwrap 플러그인이 함께 설치되어도 에러 상세를 유지한다") {
-            val client =
-                createClient(
-                    status = HttpStatusCode.InternalServerError,
+                    status = errorStatus,
                     responseBody =
                         """
                         {
@@ -73,7 +43,7 @@ class CaroResponseHandlerTest : FunSpec() {
                 )
 
             val exception =
-                shouldThrow<NetworkException> {
+                shouldThrow<CaroServerException> {
                     client.get("https://caro.test/sample").body<String>()
                 }
 
@@ -84,20 +54,22 @@ class CaroResponseHandlerTest : FunSpec() {
         }
 
         test("에러 응답 body 파싱에 실패하면 status code와 기본 메시지로 NetworkException을 만든다") {
+            val errorStatus = HttpStatusCode.BadGateway
             val client =
                 createClient(
-                    status = HttpStatusCode.BadGateway,
+                    status = errorStatus,
                     responseBody = "not-json",
                     contentType = ContentType.Text.Plain,
                 )
 
             val exception =
-                shouldThrow<NetworkException> {
-                    client.get("https://caro.test/sample").body<String>()
+                shouldThrow<CaroServerException> {
+                    client.get("https://caro.test/sample").body<Unit>()
                 }
 
             exception.code shouldBe HttpStatusCode.BadGateway.value.toString()
-            exception.message shouldBe "Server error"
+            exception.message shouldBe "Caro Server error"
+            exception.debugMessage shouldBe "Caro Server error"
             exception.description shouldBe null
         }
 
@@ -143,11 +115,7 @@ class CaroResponseHandlerTest : FunSpec() {
                 }
 
                 install(HttpCallValidator) {
-                    installCaroResponseHandler(jsonParser)
-                }
-
-                install(CaroBaseResponseUnwrap) {
-                    this.json = jsonParser
+                    configureCaroExceptionMapping(jsonParser)
                 }
             }
     }

--- a/core/remote/src/commonTest/kotlin/com/whatever/caro/core/test/plugin/ConfigureCaroExceptionMappingTest.kt
+++ b/core/remote/src/commonTest/kotlin/com/whatever/caro/core/test/plugin/ConfigureCaroExceptionMappingTest.kt
@@ -1,6 +1,9 @@
 package com.whatever.caro.core.test.plugin
 
+import com.whatever.caro.core.model.exception.CaroInvalidResponseException
 import com.whatever.caro.core.model.exception.CaroServerException
+import com.whatever.caro.core.model.exception.ErrorCode
+import com.whatever.caro.core.model.exception.NetworkException
 import com.whatever.caro.core.remote.network.plugins.configureCaroExceptionMapping
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
@@ -63,14 +66,40 @@ class ConfigureCaroExceptionMappingTest : FunSpec() {
                 )
 
             val exception =
-                shouldThrow<CaroServerException> {
+                shouldThrow<CaroInvalidResponseException> {
                     client.get("https://caro.test/sample").body<Unit>()
                 }
 
-            exception.code shouldBe HttpStatusCode.BadGateway.value.toString()
-            exception.message shouldBe "Caro Server error"
-            exception.debugMessage shouldBe "Caro Server error"
-            exception.description shouldBe null
+            exception.code shouldBe ErrorCode.INVALID_RESPONSE
+            exception.message shouldBe "Invalid Response Error"
+        }
+
+        test("응답이 없는 네트워크 오류는 NetworkException으로 변환한다") {
+            val client =
+                HttpClient(
+                    MockEngine {
+                        throw io.ktor.util.network
+                            .UnresolvedAddressException()
+                    },
+                ) {
+                    expectSuccess = true
+
+                    install(ContentNegotiation) {
+                        json(jsonParser)
+                    }
+
+                    install(HttpCallValidator) {
+                        configureCaroExceptionMapping(jsonParser)
+                    }
+                }
+
+            val exception =
+                shouldThrow<NetworkException> {
+                    client.get("https://caro.test/sample").body<Unit>()
+                }
+
+            exception.code shouldBe ErrorCode.NETWORK_001
+            exception.message shouldBe "Network Error"
         }
 
         test("정상 응답이면 NetworkException을 던지지 않는다") {

--- a/core/remote/src/commonTest/kotlin/com/whatever/caro/core/test/plugin/ConfigureCaroExceptionMappingTest.kt
+++ b/core/remote/src/commonTest/kotlin/com/whatever/caro/core/test/plugin/ConfigureCaroExceptionMappingTest.kt
@@ -56,7 +56,7 @@ class ConfigureCaroExceptionMappingTest : FunSpec() {
             exception.description shouldBe "retry later"
         }
 
-        test("에러 응답 body 파싱에 실패하면 status code와 기본 메시지로 NetworkException을 만든다") {
+        test("에러 응답 body 파싱에 실패하면 status code와 기본 메시지로 CaroInvalidResponseException을 만든다") {
             val errorStatus = HttpStatusCode.BadGateway
             val client =
                 createClient(


### PR DESCRIPTION
## 관련 이슈
- #35 

## 작업한 내용
- CaroBaseResponseConverter 플러그인 예외 로직 구현
- Server ResponseException 예외 로직 구현

## PR 포인트

### Exception 객체
- `CaroException`
  - 앱에서 공통으로 사용하는 최상위 예외 타입입니다.
  - 모든 커스텀 예외가 code, message, debugMessage를 공통으로 가지도록 맞췄습니다.
- `CaroServerException`
  - 서버가 success=false와 함께 error payload를 명시적으로 내려준 경우 사용하는 예외입니다.
  - 서버가 내려준 message를 그대로 사용자에게 노출할 수 있는 케이스입니다.
- `NetworkException`
  - 오프라인, connect/socket timeout 같은 transport 계열 오류에 사용하는 예외입니다.
  - 서버 응답이 없는 네트워크 실패를 구분하기 위한 타입입니다.
- `CaroInvalidResponseException`
  - 응답 decode 실패, 응답 계약 불일치, success=true인데 data=null인 경우처럼 정상 응답으로 해석할 수 없는 경우 사용하는 예외입니다.
  - 서버/클라이언트 중 한쪽 책임으로 단정하기 어려운 비정상 응답을 다룹니다.