### PR TITLE
[Refactor] Spotless 린팅 시간 개선

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,31 +25,35 @@ plugins {
 val ktlintCliVersion = libs.versions.ktlint.cli.get()
 
 subprojects {
+    if (!buildFile.isFile) return@subprojects
+
     apply(plugin = "com.diffplug.spotless")
 
     configure<SpotlessExtension> {
         kotlin {
-            target("**/*.kt")
-            targetExclude(
-                "**/build/**",
-                "**/generated/**"
+            target(
+                fileTree("src") {
+                    include("**/*.kt")
+                    exclude("**/generated/**")
+                }
             )
             ktlint(ktlintCliVersion)
         }
 
         kotlinGradle {
-            target("**/*.gradle.kts")
+            target("*.gradle.kts")
             ktlint(ktlintCliVersion)
         }
 
         format("xml") {
             target(
-                "src/**/values/*.xml",
-                "src/**/AndroidManifest.xml"
-            )
-            targetExclude(
-                "**/build/**",
-                "**/generated/**"
+                fileTree("src") {
+                    include(
+                        "**/values/*.xml",
+                        "**/AndroidManifest.xml"
+                    )
+                    exclude("**/generated/**")
+                }
             )
 
             eclipseWtp(EclipseWtpFormatterStep.XML)


### PR DESCRIPTION
## 작업한 내용
- Spotless 타겟 파일 수정

## PR 포인트
### 문제 원인
spotless로 린팅 작업 수행시 spm4kmp 라이브러리를 사용하면서 kotlin export시 생성되는 Gradle/SPM build 산출물(현재 `:core:analytics`, `:core:crashlytics` 모듈)까지 함께 검사하기 때문에 task time이 2분 이상 걸렸습니다. 이를 개선하기 위해 target directory 범위를 좁히고 불필요한 파일 검사는 제외하였습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 작업한 내용
- Spotless 린팅 타겟 디렉토리 및 패턴 수정
- 빌드 파일 유무 확인 로직 추가
- Kotlin 파일 및 XML 파일 검사 범위 축소

## PR 포인트
### Spotless 린팅 성능 개선
- **buildFile 검증 추가**: `subprojects` 블록에서 빌드 파일이 존재하는 프로젝트만 Spotless 플러그인 적용하도록 설정 (`if (!buildFile.isFile) return@subprojects`)
- **Kotlin 파일 검사 범위 축소**: 와일드카드 패턴 `**/*.kt`에서 `fileTree("src")` 기반의 include/exclude 구조로 변경하여 생성된 파일(`**/generated/**`) 제외
- **Gradle Kotlin 스크립트 범위 축소**: `**/*.gradle.kts` 패턴을 `*.gradle.kts`로 변경하여 루트 디렉토리의 gradle.kts 파일만 검사하도록 제한
- **XML 파일 검사 범위 축소**: `src/` 하위의 `values/*.xml`과 `AndroidManifest.xml`만 대상으로 하며, 생성된 파일 제외

### 기대 효과
- spm4kmp 라이브러리 사용으로 인해 생성되는 Gradle/SPM 빌드 산출물(`:core:analytics`, `:core:crashlytics` 모듈)의 불필요한 검사 제외
- Spotless 린팅 작업 시간을 2분 이상에서 단축 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->