### PR TITLE
[Build] CMP 1.11.0 업데이트

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ version-code = "2" # major(10), minor(01), patch(01), build(00)
 version-name = "0.0.2" # major(1), minor(1), patch(1)
 
 # Multiplatform
-compose-multiplatform = "1.10.0"
+compose-multiplatform = "1.11.0"
 kotlin = "2.3.20"
 ksp = "2.3.4"
 
@@ -29,11 +29,11 @@ kotlinx-date-time = "0.7.1"
 kotlinx-collections-immutable = "0.4.0"
 
 # org.jetbrains.compose
-compose-runtime = "1.10.0"
-compose-ui = "1.10.0"
-compose-foundation = "1.10.0"
+compose-runtime = "1.11.0"
+compose-ui = "1.11.0"
+compose-foundation = "1.11.0"
 compose-material3 = "1.10.0-alpha05"
-compose-resources = "1.10.0"
+compose-resources = "1.11.0"
 
 # org.jetbrains.androidx
 jetbrains-androidx-lifecycle = "2.10.0-alpha06"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,13 +32,13 @@ kotlinx-collections-immutable = "0.4.0"
 compose-runtime = "1.11.0"
 compose-ui = "1.11.0"
 compose-foundation = "1.11.0"
-compose-material3 = "1.10.0-alpha05"
+compose-material3 = "1.11.0-alpha07"
 compose-resources = "1.11.0"
 
 # org.jetbrains.androidx
-jetbrains-androidx-lifecycle = "2.10.0-alpha06"
-jetbrains-androidx-navigation3-ui = "1.0.0-alpha06"
-jetbrains-androidx-navigation3-event = "1.0.0"
+jetbrains-androidx-lifecycle = "2.11.0-beta01"
+jetbrains-androidx-navigation3-ui = "1.1.1"
+jetbrains-androidx-navigation3-event = "1.1.0"
 
 # DI
 koin = "4.2.1"
@@ -120,7 +120,7 @@ jetbrains-androidx-lifecycle-viewmodel-savestate = { group = "org.jetbrains.andr
 jetbrains-androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "jetbrains-androidx-lifecycle" }
 jetbrains-androidx-lifecycle-viewmodel-nav3 = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel-navigation3", version.ref = "jetbrains-androidx-lifecycle" }
 jetbrains-androidx-navigation3-ui = { group = "org.jetbrains.androidx.navigation3", name = "navigation3-ui", version.ref = "jetbrains-androidx-navigation3-ui" }
-jetbrains-androidx-navigation3-event = { group = "rg.jetbrains.androidx.navigationevent", name = "navigationevent-compose", version.ref = "jetbrains-androidx-navigation3-event" }
+jetbrains-androidx-navigation3-event = { group = "org.jetbrains.androidx.navigationevent", name = "navigationevent-compose", version.ref = "jetbrains-androidx-navigation3-event" }
 
 # DI
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }


### PR DESCRIPTION
## [관련 이슈]
- 없음

## [작업한 내용]
- Compose Multiplatform 및 Compose runtime/ui/foundation/resources 버전을 1.11.0으로 업데이트했습니다.
- CMP 1.11.0 릴리즈 라인에 맞춰 Material3를 1.11.0-alpha07로 업데이트했습니다.
- JetBrains AndroidX Lifecycle을 2.11.0-beta01로 업데이트했습니다.
- JetBrains AndroidX Navigation3 UI를 1.1.1, NavigationEvent Compose를 1.1.0으로 업데이트했습니다.
- NavigationEvent Compose 의존성 group 오타를 `rg.jetbrains...`에서 `org.jetbrains...`로 수정했습니다.
- iOS 빌드 타깃에서 `iosX64` 구성을 제거했습니다.
- `core:remote`의 `kspIosX64` KSP 의존성 구성을 제거했습니다.

## [PR 포인트]
- CMP 1.11.0 릴리즈 노트의 요구사항에 맞춰 Kotlin 2.3.20 조합을 유지하고, iOS 타깃은 `iosArm64`, `iosSimulatorArm64`만 사용하도록 정리된 상태입니다.
- `./gradlew :composeApp:compileKotlinIosSimulatorArm64` 실행 시 Coil 3.4.0이 이전 Skiko를 참조한다는 CMP 호환성 경고가 출력됩니다. 현재 Coil 최신은 3.5.0-beta01이며 CMP 1.11.0의 Skiko와도 완전히 일치하지 않아 이번 PR에서는 Coil 업데이트를 제외했습니다.
- 검증: `./gradlew :androidApp:assembleDevDebug`, `./gradlew :composeApp:compileKotlinIosSimulatorArm64`