### PR TITLE
[Chore] Compose/Kotlin/KMP Agent Skill 추가

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,57 +1,17 @@
-# `.claude/skills` — Caro-Mobile 에이전트 스킬
+# `.claude/skills`
 
-이 디렉토리의 스킬은 Claude/Codex 등 에이전트가 코딩·리뷰 시 자동 발동(description 트리거)하거나
-직접 호출(`/<skill-name>`)할 수 있다. YAML frontmatter만 Claude 전용이며, 절차·규칙은 에이전트 중립적이다.
+에이전트(Claude/Codex 등)가 코딩·리뷰 시 자동 발동(description 트리거)하거나 직접 호출(`/<skill-name>`)하는 스킬 모음.
 
-## 구성
+## 스킬
 
-### 컨벤션 단일 출처
-- **`_conventions`** — Caro 아키텍처 규칙 요약(MVI·BaseViewModel·Koin·Navigation3·Compose resources·
-  expect/actual·Kotest). 다른 스킬이 "우리 컨벤션은?"의 근거로 삼는다. 권위 원문은 루트 `CLAUDE.md`.
-
-### Compose / Kotlin / KMP 스킬 (벤더링 + 각색)
-출처: [`chrisbanes/skills`](https://github.com/chrisbanes/skills) (Apache-2.0). 원문 기술 내용을 유지하되
-예시 코드를 Caro 컨벤션(`CaroTheme`, `BaseViewModel`, Koin 단축 DSL, `stringResource(Res.string)`,
-`NavKey`, `expect/actual`, Kotest)으로 각색하고 Android 전용 표현을 CMP-안전하게 다듬었다.
-
-| 스킬 | 한 줄 |
+| 스킬 | 설명 |
 |---|---|
-| `kotlin-multiplatform-expect-actual` | expect/actual·인터페이스 경계, commonMain에 플랫폼 타입 금지 |
-| `kotlin-coroutines-structured-concurrency` | 스코프 소유, suspend API, 취소 재전파, runBlocking 회피 |
-| `kotlin-flow-state-event-modeling` | StateFlow vs Channel(sideEffect), update{}, sentinel 회피 |
-| `compose-state-authoring` | remember/mutableStateOf, @ReadOnlyComposable |
-| `compose-state-hoisting` | 상태를 로컬/holder/ViewModel 중 어디에 둘지 |
-| `compose-state-holder-ui-split` | Route(배선) / Screen(순수 UI) 분리 |
-| `compose-side-effects` | LaunchedEffect/DisposableEffect/rememberCoroutineScope, effect key |
-| `compose-recomposition-performance` | recomposition 성능 라우터(안정성/지연읽기/back-writing) |
-| `compose-slot-api-pattern` | 재사용 컴포넌트 슬롯 API(디자인시스템) |
-| `compose-ui-testing-patterns` | ViewModel/UI 테스트(Kotest+Mokkery+Turbine로 각색) |
+| `_conventions` | Caro 아키텍처 규칙 요약(MVI·Koin·Navigation3·resources·expect-actual·Kotest). 다른 스킬의 컨벤션 근거. 원문은 루트 `CLAUDE.md`. |
+| `caro-compose-review` | PR/diff를 위 컨벤션 체크리스트로 리뷰. `/caro-compose-review` 또는 "컴포즈 리뷰" 등으로 발동. |
+| `compose-*`, `kotlin-*` | Compose/Kotlin/KMP 베스트 프랙티스. 출처 [chrisbanes/skills](https://github.com/chrisbanes/skills)(Apache-2.0)를 Caro 컨벤션으로 각색. |
+| `swagger-sync` | Swagger → Kotlin DTO/API 동기화(별도 출처). |
 
-### 리뷰
-- **`caro-compose-review`** — PR/diff를 위 컨벤션 체크리스트로 리뷰. 직접 호출(`/caro-compose-review`) +
-  "컴포즈 리뷰" 등 트리거. 일반 버그 리뷰(`code-review:code-review`)와 **보완** 관계.
+## 비고
 
-### 기타
-- `swagger-sync` — Swagger → Kotlin DTO/API 동기화(별도 출처).
-
-## 멀티플랫폼 적합성
-
-- **chrisbanes/skills**: KMP+Compose Multiplatform에 적합하여 벤더링.
-- **android/skills**(AGP9·CameraX·R8·Play·Wear·XR·edge-to-edge·profilers·androidx Navigation3 등):
-  Android 전용이라 KMP+iOS 앱에 부적합 → **벤더링 제외**. 필요 시 원문 참조.
-- 제외/보류한 chrisbanes 스킬: `compose-stability-diagnostics`, `compose-state-deferred-reads`,
-  `compose-modifier-and-layout-style`, `compose-animations`, `kotlin-types-value-class`,
-  `compose-focus-navigation`, `shepherd`. 필요해지면 아래 절차로 추가.
-
-## 상류 변경 재동기화 절차
-
-1. 원문 fetch: `https://raw.githubusercontent.com/chrisbanes/skills/main/skills/<name>/SKILL.md`
-2. 우리 버전과 diff하여 새 규칙/예시 변경 파악.
-3. frontmatter는 우리 형식 유지(`name` + 한국어 트리거 description), 본문 예시는 Caro 컨벤션으로 재각색.
-4. Android 전용 표현(`Activity`, Espresso/JUnit, Hilt `@Inject`)은 CMP-안전/Caro 스택으로 치환.
-5. `_conventions`·`CLAUDE.md`로의 상호참조 링크 유지.
-
-## 라이선스
-
-벤더링한 Compose/Kotlin/KMP 스킬은 chrisbanes/skills의 Apache License 2.0을 따른다.
-각 SKILL.md 상단에 출처·라이선스를 표기했다.
+- Android 전용 스킬([android/skills](https://github.com/android/skills))은 KMP+iOS에 부적합하여 제외.
+- 벤더링 스킬은 각 SKILL.md 상단에 출처·라이선스 표기. 상류 변경 시 원문과 diff하여 예시만 재각색.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,57 @@
+# `.claude/skills` — Caro-Mobile 에이전트 스킬
+
+이 디렉토리의 스킬은 Claude/Codex 등 에이전트가 코딩·리뷰 시 자동 발동(description 트리거)하거나
+직접 호출(`/<skill-name>`)할 수 있다. YAML frontmatter만 Claude 전용이며, 절차·규칙은 에이전트 중립적이다.
+
+## 구성
+
+### 컨벤션 단일 출처
+- **`_conventions`** — Caro 아키텍처 규칙 요약(MVI·BaseViewModel·Koin·Navigation3·Compose resources·
+  expect/actual·Kotest). 다른 스킬이 "우리 컨벤션은?"의 근거로 삼는다. 권위 원문은 루트 `CLAUDE.md`.
+
+### Compose / Kotlin / KMP 스킬 (벤더링 + 각색)
+출처: [`chrisbanes/skills`](https://github.com/chrisbanes/skills) (Apache-2.0). 원문 기술 내용을 유지하되
+예시 코드를 Caro 컨벤션(`CaroTheme`, `BaseViewModel`, Koin 단축 DSL, `stringResource(Res.string)`,
+`NavKey`, `expect/actual`, Kotest)으로 각색하고 Android 전용 표현을 CMP-안전하게 다듬었다.
+
+| 스킬 | 한 줄 |
+|---|---|
+| `kotlin-multiplatform-expect-actual` | expect/actual·인터페이스 경계, commonMain에 플랫폼 타입 금지 |
+| `kotlin-coroutines-structured-concurrency` | 스코프 소유, suspend API, 취소 재전파, runBlocking 회피 |
+| `kotlin-flow-state-event-modeling` | StateFlow vs Channel(sideEffect), update{}, sentinel 회피 |
+| `compose-state-authoring` | remember/mutableStateOf, @ReadOnlyComposable |
+| `compose-state-hoisting` | 상태를 로컬/holder/ViewModel 중 어디에 둘지 |
+| `compose-state-holder-ui-split` | Route(배선) / Screen(순수 UI) 분리 |
+| `compose-side-effects` | LaunchedEffect/DisposableEffect/rememberCoroutineScope, effect key |
+| `compose-recomposition-performance` | recomposition 성능 라우터(안정성/지연읽기/back-writing) |
+| `compose-slot-api-pattern` | 재사용 컴포넌트 슬롯 API(디자인시스템) |
+| `compose-ui-testing-patterns` | ViewModel/UI 테스트(Kotest+Mokkery+Turbine로 각색) |
+
+### 리뷰
+- **`caro-compose-review`** — PR/diff를 위 컨벤션 체크리스트로 리뷰. 직접 호출(`/caro-compose-review`) +
+  "컴포즈 리뷰" 등 트리거. 일반 버그 리뷰(`code-review:code-review`)와 **보완** 관계.
+
+### 기타
+- `swagger-sync` — Swagger → Kotlin DTO/API 동기화(별도 출처).
+
+## 멀티플랫폼 적합성
+
+- **chrisbanes/skills**: KMP+Compose Multiplatform에 적합하여 벤더링.
+- **android/skills**(AGP9·CameraX·R8·Play·Wear·XR·edge-to-edge·profilers·androidx Navigation3 등):
+  Android 전용이라 KMP+iOS 앱에 부적합 → **벤더링 제외**. 필요 시 원문 참조.
+- 제외/보류한 chrisbanes 스킬: `compose-stability-diagnostics`, `compose-state-deferred-reads`,
+  `compose-modifier-and-layout-style`, `compose-animations`, `kotlin-types-value-class`,
+  `compose-focus-navigation`, `shepherd`. 필요해지면 아래 절차로 추가.
+
+## 상류 변경 재동기화 절차
+
+1. 원문 fetch: `https://raw.githubusercontent.com/chrisbanes/skills/main/skills/<name>/SKILL.md`
+2. 우리 버전과 diff하여 새 규칙/예시 변경 파악.
+3. frontmatter는 우리 형식 유지(`name` + 한국어 트리거 description), 본문 예시는 Caro 컨벤션으로 재각색.
+4. Android 전용 표현(`Activity`, Espresso/JUnit, Hilt `@Inject`)은 CMP-안전/Caro 스택으로 치환.
+5. `_conventions`·`CLAUDE.md`로의 상호참조 링크 유지.
+
+## 라이선스
+
+벤더링한 Compose/Kotlin/KMP 스킬은 chrisbanes/skills의 Apache License 2.0을 따른다.
+각 SKILL.md 상단에 출처·라이선스를 표기했다.

--- a/.claude/skills/_conventions/SKILL.md
+++ b/.claude/skills/_conventions/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: _conventions
+description: >
+  Caro-Mobile(KMP + Compose Multiplatform, com.whatever.caro)의 아키텍처 컨벤션 단일 출처.
+  MVI(BaseViewModel)·Koin 컴파일러 플러그인·Navigation3·Compose resources·expect/actual·Kotest
+  규칙을 요약한다. 다른 Compose/Kotlin/KMP 스킬이 "우리 컨벤션은?"을 물을 때 이 문서를 근거로 삼는다.
+  "Caro 컨벤션", "우리 컨벤션", "모듈 구조", "MVI 구조", "화면 추가 절차" 같은 맥락에서 사용한다.
+---
+
+# Caro 컨벤션 (단일 출처)
+
+이 문서는 벤더링한 Compose/Kotlin/KMP 스킬들이 반복 인용하는 **우리 프로젝트 규칙**을 한곳에 모은 것이다.
+권위 있는 원문은 루트 `CLAUDE.md`이며, 이 문서는 스킬 적용 시 빠르게 참조하기 위한 요약이다.
+충돌 시 `CLAUDE.md`가 우선한다.
+
+## 모듈 구조 & 의존 규칙
+
+```
+:androidApp → :composeApp
+:composeApp → :core:* + :feature:*
+:feature:*  → caro.feature 가 자동 주입: designsystem, data, ui, viewmodel, navigator
+:core:data  → :core:remote, :core:model
+:core:remote → :core:model
+```
+
+- **feature 모듈끼리 직접 의존 금지.** 화면 간 통신은 `:core:navigator`를 경유한다.
+- 공용 인프라는 `:core:*`, 화면은 `:feature:*`.
+
+## MVI (Intent / State / SideEffect)
+
+ViewModel은 `BaseViewModel<S, I, SE>`를 상속한다
+(`core/viewmodel/.../BaseViewModel.kt`). 파일 레이아웃:
+
+```
+feature/<name>/
+├── route/<Name>Route.kt   # 상태 수집 + side effect 처리 (Composable 진입점)
+├── <Name>Screen.kt        # 순수 UI (state + onIntent 콜백만 받음)
+├── <Name>ViewModel.kt     # BaseViewModel 상속, DI 모듈에 등록
+├── di/<Name>Module.kt     # Koin module { viewModel<...>() }
+└── mvi/
+    ├── <Name>Intent.kt     # sealed interface (사용자 액션)
+    ├── <Name>State.kt      # data class (UiState)
+    └── <Name>SideEffect.kt # sealed interface (1회성 이벤트)
+```
+
+`BaseViewModel`이 제공하는 것 (직접 다른 패턴을 만들지 말 것):
+
+```kotlin
+val state: StateFlow<S>          // _state = MutableStateFlow(initial).asStateFlow()
+val sideEffect: Flow<SE>         // _sideEffect = Channel<SE>(BUFFERED).receiveAsFlow()
+
+fun intent(intent: I)            // launch { handleIntent(intent) }
+protected fun reduce(reduce: S.() -> S)          // 동기 상태 갱신: reduce { copy(...) }
+protected fun postSideEffect(sideEffect: SE)     // 1회성 이벤트 emit
+protected fun launch(...) : Job  // viewModelScope + coroutineExceptionHandler
+open fun handleClientException(throwable: Throwable)  // 공통 에러 처리 훅
+protected abstract suspend fun handleIntent(intent: I)
+```
+
+- **상태 변경은 `reduce { copy(...) }`만 사용.** `_state.value =` 직접 대입 금지.
+- **1회성 이벤트(네비게이션/토스트)는 `postSideEffect`.** state에 이벤트 플래그를 넣지 말 것.
+- **비동기 작업은 `launch { }`.** 별도 `CoroutineScope`를 ViewModel에 저장하지 말 것.
+- Repository는 `suspend` 함수를 노출하고, ViewModel의 `launch`가 스코프를 소유한다.
+
+ViewModel 예시 (`feature/login/.../LoginViewModel.kt`):
+
+```kotlin
+class LoginViewModel(
+    private val authRepository: AuthRepository,
+) : BaseViewModel<LoginState, LoginIntent, LoginSideEffect>(initialState = LoginState()) {
+
+    override suspend fun handleIntent(intent: LoginIntent) { /* when(intent) ... */ }
+
+    private fun requestLogin(provider: SocialLoginType, idToken: String) {
+        launch {
+            reduce { copy(isLoading = true) }
+            authRepository.loginWithSocial(provider = provider, idToken = idToken)
+            reduce { copy(isLoading = false) }
+            postSideEffect(LoginSideEffect.NavigateHome)
+        }
+    }
+}
+```
+
+## Route / Screen 분리
+
+- **Route**: `viewModel.state.collectAsStateWithLifecycle()`로 상태 수집,
+  `LaunchedEffect`에서 `viewModel.sideEffect.collect { }`로 1회성 이벤트 처리,
+  `NavigationDispatcher`로 네비게이션 emit. (`feature/home/.../route/HomeRoute.kt`)
+- **Screen**: `@Composable internal fun XScreen(state: XState, onIntent: (XIntent) -> Unit)` —
+  의존성·flow 수집·네비게이션 없이 **순수 UI**. 미리보기/테스트 가능해야 함. (`feature/home/.../HomeScreen.kt`)
+
+```kotlin
+@Composable
+fun HomeRoute(viewModel: HomeViewModel, navDispatcher: NavigationDispatcher) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is HomeSideEffect.NavigateToProfile -> navDispatcher.emit(To(CreateProfileEntry))
+            }
+        }
+    }
+    HomeScreen(state = state, onIntent = viewModel::intent)
+}
+```
+
+## Koin DI (컴파일러 플러그인)
+
+KSP/어노테이션 없이 **Koin Kotlin 컴파일러 플러그인** 단축 DSL을 쓴다.
+
+```kotlin
+import org.koin.dsl.bind
+import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
+import org.koin.plugin.module.dsl.viewModel
+
+val homeModule = module { viewModel<HomeViewModel>() }   // 생성자 인자 자동 해결(NavKey 포함)
+
+val dataModule = module {
+    single<AuthRepositoryImpl>() bind AuthRepository::class
+}
+```
+
+평범한 DSL(`single { ... }`)은 `named()` qualifier, 빌더 설정(`Json { }`), 단순 생성자 호출이 아닐 때만 사용.
+
+## Navigation3 — 화면 추가 4단계
+
+1. `:core:navigator`에 `@Serializable`한 `NavKey` 정의 (예: `data object SettingsEntry : NavKey`).
+   파라미터는 `@Serializable data class` + `Payload` 패턴.
+2. `CaroApp.kt`의 `SavedStateConfiguration` polymorphic 블록에 `subclass(...)` 등록.
+3. `composeApp/di/NavigationModule.kt`에 `navigation<Key> { }` 추가
+   (파라미터 화면은 `koinViewModel<VM> { parametersOf(navKey) }`).
+4. feature 모듈에 Route/Screen/ViewModel/MVI 작성.
+
+네비게이션 명령은 `NavigationDispatcher`를 통해 `NavCommand`(Back/To/Replace/ResetTo)로 흐른다.
+UI는 "어디로 가라"가 아니라 SideEffect → Route에서 emit.
+
+## Compose Resources (문자열)
+
+- 사용자 노출 텍스트·접근성 라벨은 **반드시** `stringResource(Res.string...)` /
+  `painterResource(Res.drawable...)`. (`org.jetbrains.compose.resources`)
+- Screen/Route/컴포넌트에 하드코딩 문자열 금지(임시 디버그 UI 제외).
+
+## 디자인 시스템 토큰
+
+`CaroTheme` CompositionLocal로 접근:
+`CaroTheme.color.*`, `CaroTheme.typography.*`, `CaroTheme.spacing.*`, `CaroTheme.shape.*`.
+raw `Color(...)`, 매직 `dp` 색상/간격 대신 토큰 사용. (`core/designsystem/.../components/CaroTextField.kt`)
+
+## 멀티플랫폼 (expect/actual)
+
+- 플랫폼 분기는 `expect`/`actual` + 파일명 규칙 `Foo.android.kt` / `Foo.ios.kt`.
+- `commonMain` 시그니처에 플랫폼 타입(`Context`, `Activity`, `Uri`, `UIViewController`) 노출 금지.
+- 엔진 예: `core/remote/.../network/HttpClientEngineProvider.{kt, android.kt, ios.kt}` (OkHttp / Darwin).
+- DI·테스트 페이크·런타임 선택이 필요하면 `expect class` 대신 commonMain 인터페이스 + 플랫폼 바인딩.
+
+## 테스트 스택
+
+- **Kotest** `FunSpec` + `init { }`, **KoinTest** + `KoinExtension(listOf(module))`.
+- 코루틴: `StandardTestDispatcher` + `Dispatchers.setMain/resetMain` + `runTest { advanceUntilIdle() }`.
+- **Mokkery**(모킹), **Turbine**(flow), **kotlinx-coroutines-test**.
+- 소스셋: `commonTest`(공유), `androidHostTest`(Android 전용).
+
+```kotlin
+class HomeViewModelTest : FunSpec(), KoinTest {
+    init {
+        extensions(KoinExtension(listOf(homeModule)))
+        val dispatcher = StandardTestDispatcher()
+        beforeTest { Dispatchers.setMain(dispatcher) }
+        afterTest { Dispatchers.resetMain(); dispatcher.cancel() }
+
+        test("...") { runTest {
+            val vm: HomeViewModel = get { parametersOf(navKey) }
+            vm.init(); advanceUntilIdle()
+            vm.state.value shouldBe HomeState(...)
+        } }
+    }
+}
+```
+
+## 네이밍 규칙
+
+- Remote data source 구현체는 인터페이스명이 data 계층과 헷갈릴 만큼 일반적이면 `Remote` 프리픽스
+  (예: `RemoteProfileDataSourceImpl : ProfileDataSource`).
+
+## 관련 스킬
+
+이 문서를 근거로 삼는 벤더 스킬: `compose-state-holder-ui-split`, `compose-side-effects`,
+`kotlin-flow-state-event-modeling`, `kotlin-coroutines-structured-concurrency`,
+`kotlin-multiplatform-expect-actual`, `compose-slot-api-pattern`, `compose-ui-testing-patterns` 등.
+리뷰 시에는 `caro-compose-review`가 이 규칙들을 체크리스트로 적용한다.

--- a/.claude/skills/_conventions/SKILL.md
+++ b/.claude/skills/_conventions/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: _conventions
 description: >
-  Caro-Mobile(KMP + Compose Multiplatform, com.whatever.caro)의 아키텍처 컨벤션 단일 출처.
+  Caro-Mobile(KMP + Compose Multiplatform, com.whatever.caro)의 아키텍처 컨벤션 요약(스킬 참조용, 원문은 CLAUDE.md).
   MVI(BaseViewModel)·Koin 컴파일러 플러그인·Navigation3·Compose resources·expect/actual·Kotest
   규칙을 요약한다. 다른 Compose/Kotlin/KMP 스킬이 "우리 컨벤션은?"을 물을 때 이 문서를 근거로 삼는다.
   "Caro 컨벤션", "우리 컨벤션", "모듈 구조", "MVI 구조", "화면 추가 절차" 같은 맥락에서 사용한다.
 ---
 
-# Caro 컨벤션 (단일 출처)
+# Caro 컨벤션 (요약 · 스킬 참조용)
 
 이 문서는 벤더링한 Compose/Kotlin/KMP 스킬들이 반복 인용하는 **우리 프로젝트 규칙**을 한곳에 모은 것이다.
 권위 있는 원문은 루트 `CLAUDE.md`이며, 이 문서는 스킬 적용 시 빠르게 참조하기 위한 요약이다.

--- a/.claude/skills/_conventions/SKILL.md
+++ b/.claude/skills/_conventions/SKILL.md
@@ -15,7 +15,7 @@ description: >
 
 ## 모듈 구조 & 의존 규칙
 
-```
+```text
 :androidApp → :composeApp
 :composeApp → :core:* + :feature:*
 :feature:*  → caro.feature 가 자동 주입: designsystem, data, ui, viewmodel, navigator
@@ -31,7 +31,7 @@ description: >
 ViewModel은 `BaseViewModel<S, I, SE>`를 상속한다
 (`core/viewmodel/.../BaseViewModel.kt`). 파일 레이아웃:
 
-```
+```text
 feature/<name>/
 ├── route/<Name>Route.kt   # 상태 수집 + side effect 처리 (Composable 진입점)
 ├── <Name>Screen.kt        # 순수 UI (state + onIntent 콜백만 받음)

--- a/.claude/skills/caro-compose-review/SKILL.md
+++ b/.claude/skills/caro-compose-review/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: caro-compose-review
+description: >
+  Caro-Mobile(KMP + Compose Multiplatform)의 PR/diff/파일을 Compose·Kotlin·MVI·KMP 컨벤션 정합성으로 리뷰한다.
+  벤더링한 Compose/Kotlin/KMP 스킬들의 red-flag 체크리스트를 우리 규칙(MVI·BaseViewModel·Koin·Navigation3·
+  Compose resources·expect/actual·Kotest)에 맞춰 적용한다. "컴포즈 리뷰", "Compose 리뷰", "UI 리뷰",
+  "상태/사이드이펙트 점검", "MVI 리뷰", "/caro-compose-review" 같은 요청 시 사용한다. 직접 호출도 가능.
+  일반 버그·정확성 리뷰는 code-review:code-review와 보완 관계(대체 아님).
+---
+
+# Caro Compose / KMP 컨벤션 리뷰
+
+> Caro 컨벤션 단일 출처: [`../_conventions/SKILL.md`](../_conventions/SKILL.md)
+> 근거 스킬: 벤더링한 `compose-*`, `kotlin-*` 스킬들(같은 `.claude/skills/` 디렉토리). 항목마다 해당 스킬을 인용한다.
+
+## 목적과 경계
+
+- **이 스킬**: Compose/Kotlin/MVI/KMP **컨벤션 정합성**(상태 위치, side-effect API, MVI 구조, 안정성, 슬롯, expect/actual,
+  Compose resources, Koin DSL, Navigation3 등록, Kotest 패턴).
+- **`code-review:code-review`**: 일반 버그·정확성·단순화. → 대체하지 말고 **함께** 쓴다.
+- 코드를 수정하지 않고 **지적·근거 제시**가 기본. 사용자가 "고쳐줘"라고 하면 그때 수정.
+
+## 사용 방법
+
+1. 대상 diff 확보: `git diff origin/develop...HEAD`(PR) 또는 `git diff`(작업트리), 또는 사용자가 지정한 파일.
+2. 변경된 `*.kt`만 추려서 아래 체크리스트로 점검. 각 발견은 `path/to/file:line` + 위반 규칙 + 근거 스킬 링크 + 제안.
+3. 심각도 표기: **🔴 must-fix**(컨벤션 위반/버그 위험), **🟡 should-fix**(개선 권장), **🟢 nit**.
+4. 위반이 없으면 "해당 영역 통과"라고 명시. 추측으로 만들어내지 말 것.
+
+## 체크리스트
+
+### A. MVI 구조 (`_conventions`)
+- [ ] ViewModel이 `BaseViewModel<S, I, SE>`를 상속하고 `handleIntent`로 분기하는가.
+- [ ] 상태 변경이 `reduce { copy(...) }`인가. `_state.value =` 직접 대입(🔴) 없는가.
+- [ ] 1회성 이벤트(네비게이션/토스트)가 state 플래그가 아니라 `postSideEffect`인가.
+- [ ] 비동기 작업이 별도 `CoroutineScope`가 아니라 `launch { }`(viewModelScope)인가. → `kotlin-coroutines-structured-concurrency`
+- [ ] 파일 레이아웃이 `route/`, `mvi/`, `di/` 규칙을 따르는가.
+
+### B. Route / Screen 분리 (`compose-state-holder-ui-split`)
+- [ ] Screen이 `@Composable internal fun XScreen(state, onIntent)` 순수 UI인가. ViewModel/flow/네비게이션을 직접 받지 않는가(🔴).
+- [ ] Route가 `collectAsStateWithLifecycle` + `LaunchedEffect { sideEffect.collect }` + `NavigationDispatcher.emit`를 담당하는가.
+- [ ] 자식 composable에 ViewModel/component 전체를 넘기지 않는가.
+
+### C. 상태 위치 / 작성 (`compose-state-hoisting`, `compose-state-authoring`)
+- [ ] `@Composable` 본문의 `var`가 `remember { mutableStateOf() }`로 backing 되는가(🔴 아니면 리셋).
+- [ ] 비즈니스 데이터/repository 입력이 로컬 remember가 아니라 ViewModel에 있는가.
+- [ ] 컬렉션 상태가 `mutableStateListOf`/값 교체인가(`mutableStateOf(list).add` 아님).
+- [ ] composition 중 snapshot state back-writing(매 합성 `clear()`/`putAll`)이 없는가.
+
+### D. Side effects (`compose-side-effects`)
+- [ ] `LaunchedEffect`의 key가 적절한가. 바뀌는 입력을 `Unit`으로 숨기지 않는가(🔴 stale).
+- [ ] 사용자 클릭의 suspend 작업이 `rememberCoroutineScope`인가. event-flag 안티패턴 없는가.
+- [ ] `DisposableEffect` 등록에 `onDispose` 정리가 있는가.
+- [ ] composable 본문에서 네트워크/부수작업을 직접 실행하지 않는가.
+
+### E. Flow / 동시성 (`kotlin-flow-state-event-modeling`, `kotlin-coroutines-structured-concurrency`)
+- [ ] Repository/DataSource가 `suspend`만 노출하고 스코프를 저장하지 않는가(🔴).
+- [ ] `try/catch`가 `CancellationException`을 재전파하는가.
+- [ ] `runBlocking`이 앱/테스트 코드에 없는가(테스트는 `runTest`).
+- [ ] sentinel placeholder를 진짜 도메인 값처럼 쓰지 않는가.
+
+### F. 디자인시스템 / 슬롯 (`compose-slot-api-pattern`)
+- [ ] 재사용 컴포넌트가 primitive content/`showXxx` 플래그 대신 `@Composable` 슬롯을 쓰는가.
+- [ ] 색/타이포/간격/모양이 raw 값이 아니라 `CaroTheme.color/typography/spacing/shape` 토큰인가(🟡~🔴).
+- [ ] 선택 슬롯이 `(@Composable () -> Unit)? = null`인가.
+
+### G. Compose resources (`_conventions`)
+- [ ] 사용자 노출 텍스트·접근성 라벨이 `stringResource(Res.string...)`인가. **하드코딩 문자열(🔴)** 없는가(임시 디버그 제외).
+- [ ] 이미지가 `painterResource(Res.drawable...)`인가.
+
+### H. Navigation3 (`_conventions`)
+- [ ] 새 화면이 4단계를 모두 따랐는가: ① `@Serializable NavKey` 정의 ② `CaroApp.kt` polymorphic 등록
+      ③ `NavigationModule.kt`의 `navigation<Key> { }` ④ Route/Screen/ViewModel/MVI.
+- [ ] 파라미터가 `@Serializable Payload`로 전달되고, 파라미터 화면이 `koinViewModel { parametersOf(navKey) }`인가.
+- [ ] feature 모듈끼리 직접 의존하지 않는가(navigator 경유).
+
+### I. Koin DI (`_conventions`)
+- [ ] 단순 바인딩이 단축 DSL(`viewModel<X>()`, `single<X>() bind Y::class`)인가.
+- [ ] `named()`/빌더/비-생성자 로직일 때만 평범한 DSL을 쓰는가.
+
+### J. 멀티플랫폼 (`kotlin-multiplatform-expect-actual`)
+- [ ] `commonMain` 시그니처에 플랫폼 타입(`Context`, `Activity`, `Uri`, `UIViewController`)이 없는가(🔴).
+- [ ] 플랫폼 분기가 `expect`/`actual` + `*.android.kt`/`*.ios.kt`인가.
+- [ ] DI/테스트가 필요한 경계가 `expect class`가 아니라 인터페이스인가.
+
+### K. 테스트 (`compose-ui-testing-patterns`)
+- [ ] ViewModel 테스트가 Kotest `FunSpec` + `KoinTest` + `StandardTestDispatcher` + `runTest`/`advanceUntilIdle`인가.
+- [ ] `sideEffect`를 Turbine으로 검증하는가(state 단언으로 우회 안 함).
+- [ ] `advanceUntilIdle()` 없이 `launch` 결과를 단언하는 레이스가 없는가.
+
+## 출력 형식
+
+```
+## caro-compose-review 결과
+
+### 🔴 Must-fix
+- `feature/x/XScreen.kt:42` — 하드코딩 문자열 "저장". Compose resources 규칙 위반.
+  근거: compose 리뷰 G / _conventions. 제안: stringResource(Res.string.x_save).
+
+### 🟡 Should-fix
+- ...
+
+### 🟢 Nit
+- ...
+
+### 통과
+- MVI 구조, Navigation3 등록: 위반 없음.
+```
+
+## 적용 안 되는 경우
+
+- 비-Compose/비-Kotlin 변경(빌드 스크립트만, 문서만 등).
+- 일반 로직 버그 헌팅은 `code-review:code-review` 또는 `/code-review`로.

--- a/.claude/skills/caro-compose-review/SKILL.md
+++ b/.claude/skills/caro-compose-review/SKILL.md
@@ -74,6 +74,14 @@ description: >
 - [ ] 파라미터가 `@Serializable Payload`로 전달되고, 파라미터 화면이 `koinViewModel { parametersOf(navKey) }`인가.
 - [ ] feature 모듈끼리 직접 의존하지 않는가(navigator 경유).
 
+> 4단계 등록 확인용 grep (`<Entry>`를 NavKey 이름으로 치환, 예 `CreateProfileEntry`):
+> ```bash
+> grep -rn '<Entry>' core/navigator/                         # ① NavKey 정의(@Serializable)
+> grep -rn 'subclass(<Entry>' composeApp/                     # ② CaroApp.kt polymorphic 등록
+> grep -rn 'navigation<<Entry>>' composeApp/.../NavigationModule.kt  # ③ navigation<Key> { }
+> ```
+> 셋 중 하나라도 결과가 없으면 등록 누락(🔴). 빌드 산출물 오탐을 줄이려면 `--include='*.kt'`를 붙인다.
+
 ### I. Koin DI (`_conventions`)
 - [ ] 단순 바인딩이 단축 DSL(`viewModel<X>()`, `single<X>() bind Y::class`)인가.
 - [ ] `named()`/빌더/비-생성자 로직일 때만 평범한 DSL을 쓰는가.

--- a/.claude/skills/caro-compose-review/SKILL.md
+++ b/.claude/skills/caro-compose-review/SKILL.md
@@ -12,6 +12,7 @@ description: >
 
 > Caro 컨벤션 단일 출처: [`../_conventions/SKILL.md`](../_conventions/SKILL.md)
 > 근거 스킬: 벤더링한 `compose-*`, `kotlin-*` 스킬들(같은 `.claude/skills/` 디렉토리). 항목마다 해당 스킬을 인용한다.
+> 실제 적용 예시: [`examples/pr-65-create-profile.md`](examples/pr-65-create-profile.md) (PR #65에 직접 돌린 결과).
 
 ## 목적과 경계
 

--- a/.claude/skills/caro-compose-review/SKILL.md
+++ b/.claude/skills/caro-compose-review/SKILL.md
@@ -98,7 +98,7 @@ description: >
 
 ## 출력 형식
 
-```
+```text
 ## caro-compose-review 결과
 
 ### 🔴 Must-fix

--- a/.claude/skills/caro-compose-review/examples/pr-65-create-profile.md
+++ b/.claude/skills/caro-compose-review/examples/pr-65-create-profile.md
@@ -1,0 +1,70 @@
+# 적용 예시 — PR #65 (프로필 생성 화면)
+
+`caro-compose-review`를 실제 머지된 PR #65(`[Feat] 프로필 생성 화면 및 회원가입 완료 API 연동`)에
+직접 적용한 기록이다. 스킬의 "사용 방법"·체크리스트·출력 형식을 그대로 따랐다.
+
+## 1. 대상 확보
+
+```bash
+# 머지 커밋 기준 변경 파일 목록 (PR #65 = de900f1)
+git diff-tree --no-commit-id --name-only -r de900f1
+# 리뷰 대상: feature/profile/ 의 변경된 *.kt 만 추려서 점검
+```
+
+점검한 파일: `CreateProfileScreen.kt`, `CreateProfileViewModel.kt`, `CreateProfileRoute.kt`,
+`NicknameValidator.kt`, `mvi/CreateProfile{State,Intent,SideEffect}.kt`, `di/ProfileModule.kt`.
+
+## 2. Navigation3 4단계 등록 grep (체크리스트 H)
+
+```bash
+grep -rn 'CreateProfileEntry' core/navigator/ --include='*.kt'
+grep -rn 'subclass(CreateProfileEntry' composeApp/ --include='*.kt'
+grep -rn 'navigation<CreateProfileEntry>' composeApp/ --include='*.kt'
+```
+
+```text
+① core/navigator/.../entries/CreateProfileEntry.kt:7: data object CreateProfileEntry : NavKey
+② composeApp/.../CaroApp.kt:44:        subclass(CreateProfileEntry::class, CreateProfileEntry.serializer())
+③ composeApp/.../di/NavigationModule.kt:36: navigation<CreateProfileEntry> {
+```
+
+셋 다 매치 → 등록 누락 없음(통과). ④ Route/Screen/ViewModel/MVI도 존재.
+
+## 3. 결과
+
+```text
+## caro-compose-review 결과
+
+### 🟡 Should-fix
+- `feature/profile/di/ProfileModule.kt:13` — `viewModel<CreateProfileViewModel> { CreateProfileViewModel(get(), get(), get()) }`
+  처럼 명시 생성자 블록을 씀. 모든 인자가 `get()`이라 단축 DSL `viewModel<CreateProfileViewModel>()`로 줄일 수 있다.
+  같은 파일이 `single`은 `org.koin.plugin.module.dsl`(단축), `viewModel`은 `org.koin.core.module.dsl`(평범)을 섞어 import.
+  근거: _conventions Koin DSL / 체크리스트 I.
+- `feature/profile/CreateProfileViewModel.kt:48-52` — 닉네임 중복 확인 실패 시 `NicknameValidationResult.Valid`로 폴백.
+  서버 에러(가용성 unknown)를 "사용 가능" 도메인 값으로 강제. `// TODO: 서버 에러 처리 UI 확정 시 폴백 제거` 주석 있음.
+  근거: _conventions Flow/동시성 / 체크리스트 E(sentinel을 진짜 도메인 값처럼 쓰지 말 것). 의도된 임시값이나 추적 필요.
+- `feature/profile/CreateProfileScreen.kt:42-45` — `PageHorizontalPadding = 28.dp`, `CtaButtonHeight = 56.dp`,
+  `HeaderMinHeight = 17.dp` 매직 dp. 같은 화면의 `NicknameField`는 `CaroTheme.spacing.xl/m`을 쓰는데 CTA만 raw dp라 불일치.
+  근거: _conventions 디자인 토큰 / 체크리스트 F.
+- `feature/profile/CreateProfileRoute.kt` — Route가 모듈 루트에 있음. 컨벤션·`feature/home`은 `route/<Name>Route.kt`.
+  근거: _conventions 파일 레이아웃 / 체크리스트 A.
+- `feature/profile/src/commonTest` 비어 있음 — debounce·검증·에러 폴백 등 비자명 로직이 있는 ViewModel에 테스트 없음.
+  `caro.kover`가 feature에 라인 50% 최소를 강제하므로 커버리지 게이트 위험. 근거: 체크리스트 K.
+
+### 🟢 Nit
+- `CtaButton`을 Box+clickable로 직접 구성(현재 designsystem에 CaroButton 부재 — 수용 가능, 추후 컴포넌트화 후보).
+- 아이콘 `size(24.dp)`/`size(16.dp)`는 raw지만 드로어블 치수(ic_arrow_left_24/ic_renew_16)와 일치.
+
+### 통과
+- B. Route/Screen 분리: Screen이 `internal fun(state, onIntent)` 순수 UI, Route가 상태수집 + sideEffect collect + emit 담당.
+- C. 상태 작성: Screen 완전 hoisted, 비즈니스 상태는 ViewModel.
+- E(부분). suspendRunCatching로 CancellationException 재전파, repository는 suspend만 노출.
+- G. Compose resources: 모든 노출 텍스트·contentDescription이 `stringResource`. 하드코딩 문자열 없음.
+- H. Navigation3 4단계: 위 grep으로 ①②③ + ④ 전부 확인.
+- J. 멀티플랫폼: commonMain, 시그니처에 플랫폼 타입 없음.
+```
+
+## 메모
+
+- 위 발견은 **컨벤션 정합성**만 다룬다. 일반 버그·정확성은 `code-review:code-review`와 함께 본다(대체 아님).
+- 스킬은 코드를 고치지 않고 지적·근거 제시까지가 기본. 실제 수정은 사용자가 요청할 때.

--- a/.claude/skills/compose-recomposition-performance/SKILL.md
+++ b/.claude/skills/compose-recomposition-performance/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: compose-recomposition-performance
+description: >
+  Compose recomposition 성능, skippable/restartable composable, 컴파일러 리포트, recomposition 카운트,
+  cross-phase back-writing, composition vs layout/draw에서의 frame-rate State 읽기를 조사할 때 사용한다.
+  "리컴포지션 많아", "스크롤 버벅", "왜 자꾸 recompose", "안정성/stability", "성능 느려" 맥락에서 발동.
+---
+
+# Compose recomposition 성능
+
+> 출처: chrisbanes/skills (Apache-2.0) · 벤더링 2026-06-09. 라우터 스킬. 일부 하위 스킬은 벤더링하지 않아 상류 참조로 표기.
+> Caro 컨벤션 단일 출처: [`../_conventions/SKILL.md`](../_conventions/SKILL.md)
+
+라우터 전용 — 깊은 수정은 아래 초점 스킬에.
+
+## 세 축
+
+1. **파라미터 안정성 / skipping** — 이 restartable composable을 skip할 수 있나; 인자가 stable·비교 가능한가?
+2. **State를 어디서 읽나** — frame-rate State를 composition에서 읽나 layout/draw에서 읽나?
+3. **phase 간 back-writing** — 나중 phase가 앞 phase를 invalidate하는 snapshot state를 쓰나?
+   (예: composition 중 map/list 변경; `onSizeChanged`(layout)가 형제가 composition에서 읽는 state를 씀.)
+
+축 2·3은 종종 겹친다. 축 1은 독립적.
+
+## 라우팅
+
+| 주된 의심 | 다음 |
+|---|---|
+| skipping, 불안정 파라미터, 컴파일러 churn | (상류 `compose-stability-diagnostics` — 미벤더링) |
+| frame-rate State 읽기 phase | (상류 `compose-state-deferred-reads` — 미벤더링) |
+| composition 중 `putAll`/map 재구성/cross-row `height(state)` | 위 deferred-reads § back-writing |
+| composable body의 focus 기반 부수작업 | [`../compose-side-effects/SKILL.md`](../compose-side-effects/SKILL.md) — `snapshotFlow` |
+
+> Caro 참고: `compose-stability-diagnostics`, `compose-state-deferred-reads`는 핵심 세트에서 제외했다(필요 시
+> 동일 절차로 추가). 현재는 원문을 참조하라:
+> `https://github.com/chrisbanes/skills/tree/main/skills/compose-stability-diagnostics`,
+> `.../compose-state-deferred-reads`.
+
+## 리뷰 순서
+
+1. 한 전환(focus 이동, 삽입, 스크롤)을 재현하고 어떤 composable이 recompose되는지 기록.
+2. 안 바뀐 lazy item에서 카운트가 튀면, stability 탓하기 전에 back-writing(composition 변경, cross-row 측정) 확인.
+3. 스크롤/애니메이션 중 매 프레임 카운트가 오르면 deferred reads 확인.
+4. stable 데이터인데 skipping 실패하면 파라미터 안정성·컴파일러 리포트 확인.
+5. 각 수정 후 재측정.
+
+## 헛다리
+
+다음은 보통 recomposition 카운트를 줄이지 **못한다**: 같은 입력에 `remember(index)` 래핑, read-only 파생 맵의
+identity 캐시, lambda 캡처를 안정화하지 않은 hoisting(매 프레임 새 lambda 인스턴스가 skipping 무력화).
+
+## 적용 안 되는 경우
+
+- recomposition이 실제 데이터 변경을 추적하거나, 버그가 비용이 아니라 정확성일 때.
+- 프로파일러/컴파일러 신호가 문제를 시사하지 않을 때.
+
+## 관련
+
+- [`../compose-state-authoring/SKILL.md`](../compose-state-authoring/SKILL.md) — `mutableState*` 안전 작성.
+- [`../compose-side-effects/SKILL.md`](../compose-side-effects/SKILL.md) — focus 부수작업의 `snapshotFlow`.
+- [`../_conventions/SKILL.md`](../_conventions/SKILL.md).

--- a/.claude/skills/compose-recomposition-performance/SKILL.md
+++ b/.claude/skills/compose-recomposition-performance/SKILL.md
@@ -34,7 +34,7 @@ description: >
 > Caro 참고: `compose-stability-diagnostics`, `compose-state-deferred-reads`는 핵심 세트에서 제외했다(필요 시
 > 동일 절차로 추가). 현재는 원문을 참조하라:
 > `https://github.com/chrisbanes/skills/tree/main/skills/compose-stability-diagnostics`,
-> `.../compose-state-deferred-reads`.
+> `https://github.com/chrisbanes/skills/tree/main/skills/compose-state-deferred-reads`.
 
 ## 리뷰 순서
 

--- a/.claude/skills/compose-side-effects/SKILL.md
+++ b/.claude/skills/compose-side-effects/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: compose-side-effects
+description: >
+  Compose에서 LaunchedEffect, DisposableEffect, SideEffect, rememberCoroutineScope, rememberUpdatedState,
+  snapshotFlow, snackbar, navigation, focus 요청, analytics, 이벤트 Flow 수집을 작성·리뷰할 때 사용한다.
+  "LaunchedEffect", "DisposableEffect", "sideEffect collect", "effect key", "Unit으로 둬도 돼?",
+  "rememberCoroutineScope" 맥락에서 발동. Caro Route의 sideEffect 수집·스낵바·네비게이션에 적용.
+---
+
+# Compose: side effects
+
+> 출처: chrisbanes/skills (Apache-2.0) · 벤더링 2026-06-09. Caro Route 패턴 노트 추가.
+> Caro 컨벤션 단일 출처: [`../_conventions/SKILL.md`](../_conventions/SKILL.md)
+
+## Caro 적용 노트
+
+- Route에서 1회성 이벤트는 `LaunchedEffect`로 `viewModel.sideEffect.collect { }` 수집(`LoginRoute.kt` 참조).
+- 스낵바·소셜로그인 같은 사용자 이벤트 기반 suspend 작업은 `rememberCoroutineScope`에서 launch.
+- 화면 상태 자체는 effect로 imperatively 수집하지 말고 `state.collectAsStateWithLifecycle()`로
+  ([`../compose-state-holder-ui-split/SKILL.md`](../compose-state-holder-ui-split/SKILL.md)).
+- 비-suspend setter를 `LaunchedEffect`에 넣지 말 것 — 잘못된 effect 타입.
+
+## Core principle
+
+Composable body는 UI를 기술한다. recompose·skip·abandon될 수 있다. 바깥 세계를 바꾸는 작업은
+그 작업의 lifecycle에 맞는 effect API에 넣는다.
+
+## 가장 작은 effect 고르기
+
+| 필요 | API |
+|---|---|
+| 성공적 recomposition마다 Compose 상태를 비-Compose 코드에 발행 | `SideEffect` |
+| listener/콜백/observer/리소스 등록·해제 | `DisposableEffect(keys...)` |
+| suspend·지연·keyed 1회성 작업 | `LaunchedEffect(keys...)` |
+| 사용자 이벤트 콜백에서 suspend 작업 시작 | `rememberCoroutineScope()` |
+| Compose snapshot 읽기를 코루틴 안 Flow로 | `LaunchedEffect` 안 `snapshotFlow { ... }` |
+
+## Effect key
+
+key는 재시작 정체성을 정의한다. key가 바뀌면 기존 effect가 취소/dispose되고 새로 시작한다.
+
+```kotlin
+// ✅ userId 바뀌면 수집 재시작
+LaunchedEffect(userId) { repository.events(userId).collect { handle(it) } }
+
+// ❌ Unit이 바뀌는 입력을 숨김 — 수집은 첫 userId를 계속 씀
+LaunchedEffect(Unit) { repository.events(userId).collect { handle(it) } }
+```
+
+안정적·의미적 key 사용(`userId`, `screenId`). `state`/`viewModel`처럼 광범위한 객체를 한 속성만 중요할 때 쓰지 말 것.
+
+> Caro 참고: Route의 `LaunchedEffect(Unit) { viewModel.sideEffect.collect { } }`는 sideEffect Flow가 화면 lifecycle
+> 전체와 동일하므로 `Unit` 키가 맞다. 단 **수집 람다 안에서 바뀌는 입력을 캡처**하면 stale 위험 — `rememberUpdatedState` 검토.
+
+## stale 캡처 피하기
+
+재시작하면 안 되지만 최신 콜백/값이 필요한 장기 effect엔 `rememberUpdatedState`:
+
+```kotlin
+@Composable
+fun Timeout(onTimeout: () -> Unit) {
+    val latestOnTimeout by rememberUpdatedState(onTimeout)
+    LaunchedEffect(Unit) { delay(1_000); latestOnTimeout() }
+}
+```
+
+바뀐 값이 작업을 재시작해야 하면 `rememberUpdatedState`가 아니라 key로 만든다. 또한 `rememberUpdatedState`
+delegate를 `remember {}` 블록이나 객체 생성자에서 **즉시 읽으면** 값이 1회만 캡처돼 갱신 안 됨 — 그 땐 `remember(key)` 사용.
+
+## Flow 수집
+
+이벤트/side-effect flow(스낵바·네비게이션·analytics)는 `LaunchedEffect`로:
+
+```kotlin
+LaunchedEffect(events) { events.collect { snackbarHostState.showSnackbar(it.message) } }
+```
+
+렌더 상태는 effect로 imperatively 수집해 로컬 상태로 옮기지 말 것 — 상태홀더 근처에서 수집해 plain 값으로 내려보냄
+([`../compose-state-holder-ui-split/SKILL.md`](../compose-state-holder-ui-split/SKILL.md)).
+Android/lifecycle 타깃에선 `collectAsStateWithLifecycle()`, 그 외엔 `collectAsState()`.
+
+Compose 상태 읽기는 `snapshotFlow`:
+
+```kotlin
+LaunchedEffect(listState) {
+    snapshotFlow { listState.firstVisibleItemIndex }
+        .distinctUntilChanged()
+        .collect { analytics.visibleIndex(it) }
+}
+```
+
+`snapshotFlow { }.map { }`만 하고 terminal `collect`가 없으면 아무 일도 안 한다.
+
+## 사용자 이벤트
+
+클릭/제스처가 suspend 작업을 시작하면 `rememberCoroutineScope()`:
+
+```kotlin
+@Composable
+fun SaveButton(snackbarHostState: SnackbarHostState) {
+    val scope = rememberCoroutineScope()
+    Button(onClick = { scope.launch { snackbarHostState.showSnackbar("Saved") } }) { Text("Save") }
+}
+```
+
+`LaunchedEffect`를 트리거하려고 "event flag" 상태를 만들지 말 것. 클릭이 곧 이벤트다.
+
+## 등록과 정리
+
+```kotlin
+DisposableEffect(owner, observer) {
+    owner.lifecycle.addObserver(observer)
+    onDispose { owner.lifecycle.removeObserver(observer) }
+}
+```
+
+모든 등록 경로엔 대응하는 `onDispose` 정리가 있어야 한다.
+
+## 흔한 실수
+
+| 실수 | 진단 | 수정 |
+|---|---|---|
+| composable body에서 네트워크 요청 | composition 중 부수작업 | ViewModel/상태홀더로(Caro: `BaseViewModel.launch`); UI-소유 keyed 작업만 `LaunchedEffect` |
+| body에서 analytics 속성 쓰기 | composition 중 부수작업 | 매 성공 recomposition 후면 `SideEffect` |
+| `LaunchedEffect(Unit)`이 바뀌는 `id` 캡처 | key 누락 | `id`로 key, 또는 재시작 막아야 하면 `rememberUpdatedState` |
+| `LaunchedEffect(...) { nonSuspendSetter() }` | 잘못된 effect 타입 | 보통 `SideEffect` |
+| `LaunchedEffect`에서 listener 추가 후 정리 없음 | dispose 누락 | `DisposableEffect` |
+| 클릭에서 `shouldShowSnackbar = true`로 launch | event flag 안티패턴 | 클릭 콜백에서 `rememberCoroutineScope()` |
+
+## 리뷰 시 위험 신호
+
+- composable body 코드에 대해 "이건 한 번만 실행돼".
+- 바뀌는 파라미터가 있는 함수의 `LaunchedEffect(Unit)`.
+- terminal collect 없는 effect 안 flow 체인.
+- lifecycle을 모델링하지 않고 lint 침묵용으로 고른 effect key.
+- key도 `rememberUpdatedState`도 없이 장기 effect에서 쓰는 콜백 람다.
+
+## 관련
+
+- [`../compose-state-authoring/SKILL.md`](../compose-state-authoring/SKILL.md) — 로컬 상태 작성.
+- [`../compose-state-holder-ui-split/SKILL.md`](../compose-state-holder-ui-split/SKILL.md) — Route/Screen 분리, 상태 수집.
+- [`../kotlin-flow-state-event-modeling/SKILL.md`](../kotlin-flow-state-event-modeling/SKILL.md) — 이벤트 flow 모델링.
+- [`../_conventions/SKILL.md`](../_conventions/SKILL.md) — Caro Route sideEffect 수집.

--- a/.claude/skills/compose-slot-api-pattern/SKILL.md
+++ b/.claude/skills/compose-slot-api-pattern/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: compose-slot-api-pattern
+description: >
+  caller마다 시각 영역이 달라지는 재사용 Compose 컴포넌트를 설계·리뷰하거나, primitive content 파라미터와
+  boolean shape 플래그가 쌓일 때 사용한다. "슬롯 API", "재사용 컴포넌트", "title: String 파라미터",
+  "showXxx 플래그", "디자인시스템 컴포넌트" 맥락에서 발동. Caro core:designsystem(CaroTextField 등) 설계에 적용.
+---
+
+# Compose: 슬롯 API 패턴
+
+> 출처: chrisbanes/skills (Apache-2.0) · 벤더링 2026-06-09. 예시를 Caro 디자인시스템(CaroTheme/CaroTextField)으로 각색.
+> Caro 컨벤션 단일 출처: [`../_conventions/SKILL.md`](../_conventions/SKILL.md)
+
+## Caro 적용 노트
+
+- `core:designsystem` 재사용 컴포넌트는 `@Composable () -> Unit` 슬롯으로 content를 caller에 위임한다.
+  실제 예 `CaroTextField`: `header`, `footer`, `trailingIcon`을 `@Composable (() -> Unit)? = null` 슬롯으로 받음.
+- 기본 helper는 `XxxDefaults`에, 색/타이포는 `CaroTheme.color/typography` 토큰으로.
+- 단일 사용 컴포넌트나 "모든 caller가 똑같이 보여야 하는" primitive(예: 고정 스타일 `Heading`)는 슬롯화하지 않는다.
+
+## Core principle
+
+재사용 컴포넌트의 일은 **무엇을 배치하는지 나열하는 게 아니라 배치하는 것**이다.
+`title: String, subtitle: String?, leadingIcon: ImageVector?, trailingText: String?, showSwitch: Boolean...`를
+쓰는 순간 컴포넌트는 레이아웃 기술을 멈추고 call site를 나열하기 시작한다 — 다음 call site는 또 없는 파라미터를 원한다.
+
+수정은 `@Composable` 람다 파라미터로 **content를 caller에 위임**하는 것. 컴포넌트는 구조(어디에 leading/headline/
+trailing이 가는지)를 기여하고, caller는 그 슬롯에 들어갈 모든 것을 기여한다. Material3 `ListItem`이 정석.
+
+## 1. primitive content를 @Composable 슬롯으로
+
+```kotlin
+// ❌ BAD — primitive 파라미터; trailing만 슬롯, 나머지는 고정
+@Composable
+fun SettingsRow(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    leadingIcon: ImageVector? = null,
+    trailing: (@Composable () -> Unit)? = null,
+) { … }
+
+// ✅ GOOD — 모든 시각 영역이 슬롯 (CaroTextField의 header/footer/trailingIcon과 동일 정신)
+@Composable
+fun SettingsRow(
+    headlineContent: @Composable () -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    supportingContent: (@Composable () -> Unit)? = null,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
+) { … }
+```
+
+call site는 짧게 유지되고(`{ Text("Account") }`), Badge/아바타 같은 케이스도 새 파라미터 없이 해결된다.
+
+### 슬롯 네이밍
+
+- 자유형 슬롯은 `xxxContent`(`headlineContent`, `trailingContent`) — Material3 일치.
+- 의미가 제약되고 컴포넌트명이 모호성을 없애면 단수 명사(`title`, `actions`, `header`, `footer` — Caro `CaroTextField` 스타일).
+- 한 컴포넌트에 `content`와 다른 `xxxContent`를 섞지 말 것.
+
+## 2. 슬롯이 레이아웃으로 emit하면 scope receiver
+
+슬롯 content가 `Row`/`Column`/`Box`에 들어가고 그 레이아웃 기능(`Modifier.weight`, 정렬)이 caller에 필요하면
+receiver 람다로:
+
+```kotlin
+// ✅ caller가 RowScope를 받아 .weight() 사용 가능
+@Composable
+fun MyTopBar(
+    title: @Composable () -> Unit,
+    actions: @Composable RowScope.() -> Unit = {},
+)
+```
+
+receiver는 실제 부모 레이아웃에 맞춘다(`BoxScope`/`ColumnScope`). 반사적으로 모든 슬롯에 붙이지 말 것.
+
+## 3. 선택적 슬롯 — nullable + null 기본값
+
+```kotlin
+// ❌ BAD — 빈 람다 기본값; 레이아웃이 빈 슬롯 공간을 여전히 할당
+leadingContent: @Composable () -> Unit = {}
+
+// ✅ GOOD — null이면 "슬롯 없음"; 컴포넌트가 공간/패딩을 생략 가능 (CaroTextField가 이 방식)
+leadingContent: (@Composable () -> Unit)? = null
+```
+
+`CaroTextField`도 `header`/`footer`/`trailingIcon`을 nullable로 받아 `?.invoke()` / `!= null` 분기로 공간을 생략한다.
+
+## 4. 기본값은 XxxDefaults 에
+
+"보통 chevron", "기본 배경색"을 문서화하게 되면 컴포넌트 옆 `XxxDefaults` object에 co-locate:
+
+```kotlin
+object SettingsRowDefaults {
+    @Composable
+    fun Chevron() = Icon(
+        painter = painterResource(Res.drawable.ic_chevron_right_24),
+        contentDescription = null,
+        tint = CaroTheme.color.icon.tertiary,
+    )
+}
+```
+
+Material3의 `ButtonDefaults`, Caro의 토큰 기반 기본값과 동일 정신. composable 기본값을 새 파라미터로 inline하지 말 것.
+
+## Quick reference
+
+| 증상 | 진단 | 수정 |
+|---|---|---|
+| 재사용 컴포넌트에 `title: String, leadingIcon: ImageVector?` | primitive content (§1) | `xxxContent: (@Composable () -> Unit)?` 슬롯으로 |
+| trailing shape 고르는 boolean 플래그(`showChevron`) | shape 나열 (§1) | 하나의 `trailingContent` 슬롯 |
+| `Row` body 안 `actions: @Composable () -> Unit = {}` | scope receiver 누락 (§2) | `@Composable RowScope.() -> Unit = {}` |
+| 선택 영역에 `slot: @Composable () -> Unit = {}` | 빈 람다 기본값 (§3) | `(@Composable () -> Unit)? = null` + 분기 |
+| 파라미터에 `color: Color = CaroTheme.color...` inline | 기본값 inline (§4) | `XxxDefaults`로 이동 |
+
+## 적용 안 되는 경우
+
+- **단일 사용 컴포넌트.** 슬롯 indirection이 오히려 읽기 어려움 — primitive + inline content 괜찮음. (두 번째 call site 생기면 슬롯화.)
+- **모든 caller가 동일해야 하는 디자인시스템 primitive**(`Heading2(text: String)`) — 일관성이 목적이면 primitive 유지.
+- **의도적으로 컴포넌트가 소유하는 의미 파라미터**(타이포·접근성 문구·제품 일관성).
+- **`Switch(checked, onCheckedChange)`** 같은 boolean+콜백 — "content"가 아니다.
+
+## 리뷰 시 위험 신호
+
+| 생각 | 현실 |
+|---|---|
+| "title은 *항상* String이라 슬롯은 과설계" | "오늘은 항상"이 함정. `Text + Badge`가 내일 필요. 슬롯은 call site당 `{ Text(…) }` 몇 글자, 나중 추가는 모든 call site를 수정. |
+| "람다가 String보다 무겁다" | 일반 UI 규모에선 측정 불가 — 프레임워크 컴포넌트도 전부 슬롯. |
+| "trailing만 슬롯하고 leading은 항상 아이콘" | 부분-슬롯 함정. 아바타/이모지가 필요한 순간 깨짐. leading도 슬롯. |
+
+## 관련
+
+- [`../compose-state-holder-ui-split/SKILL.md`](../compose-state-holder-ui-split/SKILL.md) — 디자인시스템 primitive는 상태홀더가 아니라 슬롯/modifier 노출.
+- [`../_conventions/SKILL.md`](../_conventions/SKILL.md) — CaroTheme 토큰, designsystem 규칙.

--- a/.claude/skills/compose-slot-api-pattern/SKILL.md
+++ b/.claude/skills/compose-slot-api-pattern/SKILL.md
@@ -97,7 +97,7 @@ leadingContent: (@Composable () -> Unit)? = null
 object SettingsRowDefaults {
     @Composable
     fun Chevron() = Icon(
-        painter = painterResource(Res.drawable.ic_chevron_right_24),
+        painter = painterResource(Res.drawable.ic_chevron_right_24), // 예시 — 실제 존재하는 드로어블로 교체
         contentDescription = null,
         tint = CaroTheme.color.icon.tertiary,
     )

--- a/.claude/skills/compose-state-authoring/SKILL.md
+++ b/.claude/skills/compose-state-authoring/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: compose-state-authoring
+description: >
+  Compose에서 @Composable 안의 bare local var, remember { mutableStateOf(...) },
+  mutableStateListOf/mutableStateMapOf, @ReadOnlyComposable 을 작성·리뷰할 때 사용한다.
+  "remember", "mutableStateOf", "상태가 리셋돼", "ReadOnlyComposable", "로컬 상태" 맥락에서 발동.
+  Caro의 Screen/디자인시스템 컴포넌트의 로컬 UI 상태 작성에 적용.
+---
+
+# Compose 상태 작성
+
+> 출처: chrisbanes/skills (Apache-2.0) · 벤더링 2026-06-09. 원문 유지.
+> Caro 컨벤션 단일 출처: [`../_conventions/SKILL.md`](../_conventions/SKILL.md)
+
+## Caro 적용 노트
+
+- 화면 수준 상태는 `BaseViewModel`의 `state`/`reduce`에 둔다. 이 스킬은 **순수 UI 로컬 상태**
+  (텍스트 포커스, 펼침 여부 등 Screen/컴포넌트 내부 상태)에만 적용된다.
+- `CaroTextField`처럼 디자인시스템 컴포넌트는 `interactionSource = remember { MutableInteractionSource() }`,
+  `collectIsFocusedAsState()`를 쓴다(이미 올바른 패턴).
+- 비즈니스 데이터가 얽히면 이 스킬이 아니라 [`../compose-state-hoisting/SKILL.md`](../compose-state-hoisting/SKILL.md)로.
+
+이 스킬이 다루는 범위: **로컬 UI 상태**(`remember { mutableStateOf(…) }`, `mutableStateListOf`/`mutableStateMapOf`)와
+**`@ReadOnlyComposable`**. 코루틴 스코프/effect는 [`../compose-side-effects/SKILL.md`](../compose-side-effects/SKILL.md)로.
+
+## Core principle
+
+`@Composable`은 입력이 바뀌면 런타임이 다시 실행하는 함수다. 로컬 상태를 올바로 쓰려면 두 질문:
+
+1. **가변 로컬 상태** — 내 `var`가 recomposition을 견디고 *동시에* recomposition을 유발하는가? 아니면 매번 리셋되고 쓰기가 보이지 않는다.
+2. **이 composable은 어떤 종류인가?** — composition을 *변경*(노드 배치, slot 할당, `remember`)하나, 아니면 *읽기*만 하나? 읽기만 하면 `@ReadOnlyComposable`로 작업을 건너뛸 수 있다.
+
+## 1. composable 안의 var 는 State-backed 여야
+
+```kotlin
+// ❌ BAD — 매 recomposition마다 count 리셋, 클릭이 UI에 반영 안 됨
+@Composable
+fun Counter() {
+    var count = 0
+    Button(onClick = { count++ }) { Text("$count") }
+}
+
+// ✅ GOOD — remember(생존) + mutableStateOf(유발)
+@Composable
+fun Counter() {
+    var count by remember { mutableStateOf(0) }
+    Button(onClick = { count++ }) { Text("$count") }
+}
+```
+
+같은 규칙이 `Row { }`/`Column { }` 같은 **content 람다 안에도** 적용된다(그것도 `@Composable`).
+
+컬렉션은 `mutableStateListOf`/`mutableStateMapOf`를 선호. `remember { mutableStateOf(mutableListOf()) }` 후
+`list.add(x)`는 recompose하지 않는다(State setter를 안 거침) — 값을 교체(`state = state + x`)하거나 `mutableStateListOf` 사용.
+
+### 합성 중 snapshot state 되쓰기(back-writing) 금지
+
+```kotlin
+// ❌ BAD — 매 합성마다 clear + putAll
+val merged = remember { mutableStateMapOf<Key, ViewState>() }
+merged.clear(); merged.putAll(parent); merged.putAll(overlay)
+
+// ✅ GOOD — 입력으로부터 불변 스냅샷 remember
+val merged = remember(parent, overlay) {
+    if (overlay.isEmpty()) parent else parent + overlay
+}
+```
+
+### 적용 안 되는 경우
+
+- `remember { }` producer 블록 안(키 변경 시 1회 실행) — 로컬 `var` 정상.
+- composable 밖으로 전달되는 비-`@Composable` 람다(`onClick = { var a = 0 }`) — 평범한 Kotlin.
+- 평범한 헬퍼 함수.
+
+## 2. @ReadOnlyComposable 계약
+
+`@ReadOnlyComposable`은 composition state를 *읽기만* 한다고 선언한다 — `Text`/`Box`/`remember`/레이아웃 노드/effect 없음.
+런타임이 그룹 할당을 건너뛸 수 있어 빠른 accessor(`CaroTheme.color.*` 같은 토큰 접근자)에 유용.
+
+계약은 양방향:
+
+- body의 모든 composable 호출이 `@ReadOnlyComposable`이거나(또는 호출 자체가 없으면) **추가**.
+- 비-read-only composable을 하나라도 호출하면 **금지**.
+
+```kotlin
+// ✅ GOOD — composition local만 읽고 레이아웃/remember 없음
+@Composable
+@ReadOnlyComposable
+fun appSpacing(): Dp = LocalDimensions.current.spacing
+
+// ❌ BAD — read-only 선언인데 Box 배치
+@Composable @ReadOnlyComposable
+fun Header(): Int { Box {}; return 42 }
+```
+
+## Quick reference
+
+| 증상 | 진단 | 수정 |
+|---|---|---|
+| `@Composable fun` body의 `var x = …` | recomposition-safe 아님 | `var x by remember { mutableStateOf(…) }` |
+| content 람다 안 `var x = …` | 동일 | 동일 |
+| `remember { mutableStateOf(list) }` 후 `.add(x)` 미반영 | State setter 우회 | `mutableStateListOf` 또는 값 교체 |
+| body에서 `stateMap.clear(); putAll(...)` | composition→composition 되쓰기 | `remember(keys) { derivedSnapshot }` |
+| `Text`/`Box`/`remember`/effect 없는 `@Composable fun` | `@ReadOnlyComposable` 후보 | 추가 |
+| `Box {}` 호출하는 `@ReadOnlyComposable` | 계약 위반 | 제거 |
+
+## 리뷰 시 위험 신호
+
+| 생각 | 현실 |
+|---|---|
+| "작은 composable이라 bare var 괜찮아" | recomposition은 언제든 발생. 리셋은 비결정적 — 나중에 버그 리포트 하나. |
+| "단순해 보여서 @ReadOnlyComposable 붙였어" | 기준은 "단순"이 아니라 "read-only 호출만 한다". |
+| "그냥 리스트에 .add() 할래" | `mutableStateOf(List)`는 내부 변경을 관찰 안 함 — `mutableStateListOf`/값 교체. |
+
+## 관련
+
+- [`../compose-side-effects/SKILL.md`](../compose-side-effects/SKILL.md) — LaunchedEffect/DisposableEffect/rememberCoroutineScope 등.
+- [`../compose-state-hoisting/SKILL.md`](../compose-state-hoisting/SKILL.md) — 상태를 어디에 둘지.
+- [`../_conventions/SKILL.md`](../_conventions/SKILL.md) — Caro MVI/디자인시스템.

--- a/.claude/skills/compose-state-hoisting/SKILL.md
+++ b/.claude/skills/compose-state-hoisting/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: compose-state-hoisting
+description: >
+  Compose UI 상태/로직을 어디에 둘지(로컬 remember, hoisted 파라미터, plain state holder,
+  화면 수준 ViewModel) 결정할 때 사용한다. "상태 끌어올리기", "state hoisting", "remember 어디",
+  "이 상태 ViewModel로?", "state holder" 맥락에서 발동. Caro는 화면 상태=BaseViewModel, UI 로컬 상태=Screen/holder.
+---
+
+# Compose 상태 끌어올리기 (state hoisting)
+
+> 출처: chrisbanes/skills (Apache-2.0) · 벤더링 2026-06-09. Android 전용 표현(Activity recreation)을 CMP-안전 표현으로 각색.
+> Caro 컨벤션 단일 출처: [`../_conventions/SKILL.md`](../_conventions/SKILL.md)
+
+## Caro 적용 노트
+
+- **비즈니스 데이터·repository 호출·화면 UI 상태 생산은 `BaseViewModel`**(화면 수준 상태홀더)에 둔다.
+  `state`/`reduce`/`postSideEffect`가 그 자리. → [`../compose-state-holder-ui-split/SKILL.md`](../compose-state-holder-ui-split/SKILL.md)
+- 순수 UI 요소 상태(스크롤·포커스·펼침·텍스트 편집)는 Screen/컴포넌트 로컬에 둔다.
+- repository 기반 화면 상태를 만드는 입력(예: 닉네임 중복확인을 부르는 텍스트)은 ViewModel로 올린다.
+- **`CaroTextField`처럼 재사용 컴포넌트의 `interactionSource`, focus, 텍스트는 컴포넌트 로컬**에 두고
+  hoisting은 정말 부모가 그 동작을 조율할 때만.
+
+## Core principle
+
+상태는 로직이 필요한 만큼만 끌어올린다. 단순 UI 요소 상태는 로컬에 두고, 공유되는 UI 요소 상태는 가장 낮은 공통
+composable 소유자로 올리고, UI-전용 동작이 개념이 되면 plain state holder를 추출하고, 비즈니스 로직·앱 데이터가
+얽히면 화면 상태홀더(Caro의 `BaseViewModel`)를 쓴다.
+
+## 결정 가이드
+
+| 상황 | 소유자 |
+|---|---|
+| 한 composable이 단순 상태를 읽고 씀 | `remember` / `rememberSaveable`로 로컬 유지 |
+| 형제/부모 composable이 읽고 써야 함 | 가장 낮은 공통 조상으로 상태와 이벤트 hoist |
+| 연관 UI 요소 상태 + UI 로직이 composable을 읽기/미리보기/테스트 어렵게 만듦 | composition에 remember된 plain state holder 클래스 추출 |
+| repository 호출·영속·비즈니스 규칙·화면 UI 상태 생산이 얽힘 | 화면 수준 상태홀더(Caro `BaseViewModel`) |
+
+## plain state holder 추출 트리거
+
+다음이 여럿 성립하면 추출: 같은 콜백이 조율하는 다수의 `remember` 값, 스크롤/포커스/텍스트/선택/시트 상태가
+`clear`/`submit`/`jumpToTop` 같은 명명 연산을 필요로 함, 파생 UI 플래그가 흩어짐, 자식이 개념상 소유하지 않는
+메커니즘을 받음. **boolean 하나, 텍스트 필드 하나, 단순 show/hide엔 추출하지 말 것** — 의례는 관심사 분리가 아니다.
+
+## 패턴
+
+```kotlin
+@Stable
+class ProductSearchState(
+    query: String,
+    private val listState: LazyListState,
+    private val focusRequester: FocusRequester,
+) {
+    var query by mutableStateOf(query); private set
+    var filtersOpen by mutableStateOf(false); private set
+    val canClear: Boolean get() = query.isNotEmpty()
+
+    fun updateQuery(value: String) { query = value }
+    fun clear() { query = ""; focusRequester.requestFocus() }
+    suspend fun jumpToTop() { listState.animateScrollToItem(0) }
+}
+
+@Composable
+fun rememberProductSearchState(
+    initialQuery: String = "",
+    listState: LazyListState = rememberLazyListState(),
+    focusRequester: FocusRequester = remember { FocusRequester() },
+): ProductSearchState = remember(listState, focusRequester) {
+    ProductSearchState(initialQuery, listState, focusRequester)
+}
+```
+
+부모가 같은 UI 동작을 조율해야 하면 holder를 기본값 있는 파라미터로 받는다.
+
+## composition 소유권
+
+`remember`로 만든 plain state holder는 composable lifecycle을 따른다. `LazyListState`, `FocusRequester`,
+`PagerState`, `DrawerState`, `TextFieldState` 같은 Compose UI 객체의 좋은 집이다.
+
+frame clock이 필요한 suspend UI 연산(스크롤/드로어 애니메이션)은 composition-스코프 코루틴
+(`rememberCoroutineScope`, `LaunchedEffect`)에 둔다. **이런 호출을 `viewModelScope`로 옮기지 말 것.**
+
+## 상태 저장
+
+`rememberSaveable`이나 커스텀 `Saver`는 **구성 재생성(프로세스/화면 재생성)을 살아남아야 하는 값**
+(쿼리 문자열, 선택된 필터 ID, 현재 탭 키)에만 쓴다.
+
+> Caro/CMP 참고: Android에선 Activity/프로세스 재생성, 데스크탑·iOS 타깃에서도 동일한 "재생성 생존" 의미다.
+> 화면 간 영속이 필요한 파라미터는 Navigation3의 `@Serializable NavKey`/`Payload`로 전달한다
+> ([`../_conventions/SKILL.md`](../_conventions/SKILL.md)). `LazyListState`/`FocusRequester`/코루틴 스코프/콜백 같은
+> 런타임 객체를 직접 저장하려 하지 말 것 — 동작을 재구성할 최소 직렬화 값만 저장.
+
+## 흔한 실수
+
+| 실수 | 수정 |
+|---|---|
+| "혹시 몰라" 모든 로컬 상태를 부모로 올림 | 실제로 읽고 쓰는 가장 낮은 소유자로만 |
+| boolean 하나에 plain state holder 추출 | 단순 private UI 상태는 로컬 유지 |
+| Compose state holder에 repository 호출/제품 규칙 | 화면 상태홀더(`BaseViewModel`)로 이동 |
+| 텍스트/선택이 repository 기반 화면 상태를 구동하는데 로컬 유지 | 비즈니스 로직 있는 화면 상태홀더로 이동 |
+| holder를 무관한 자식 깊이 전달 | 자식이 정말 holder 동작을 조율하지 않으면 plain 값/콜백 전달 |
+| 애니메이션 suspend를 `viewModelScope`에서 호출 | composition-스코프 코루틴 사용 |
+
+## 관련
+
+- [`../compose-state-authoring/SKILL.md`](../compose-state-authoring/SKILL.md) — 올바른 로컬 remember/가변 상태.
+- [`../compose-state-holder-ui-split/SKILL.md`](../compose-state-holder-ui-split/SKILL.md) — 화면 상태홀더 배선과 UI 렌더 분리.
+- [`../compose-side-effects/SKILL.md`](../compose-side-effects/SKILL.md) — effect API와 composition-스코프 코루틴.
+- [`../_conventions/SKILL.md`](../_conventions/SKILL.md) — Caro MVI/Navigation3.

--- a/.claude/skills/compose-state-holder-ui-split/SKILL.md
+++ b/.claude/skills/compose-state-holder-ui-split/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: compose-state-holder-ui-split
+description: >
+  Compose 화면 수준 composable이 ViewModel/component를 받아 상태·effect를 수집하고 네비게이션·콜백을 배선하면서
+  동시에 레이아웃까지 그릴 때 사용한다. "Route/Screen 분리", "ViewModel을 화면에 직접", "미리보기가 안 돼",
+  "상태홀더 분리", "순수 UI composable" 맥락에서 발동. Caro의 Route(배선) / Screen(순수 UI) 패턴과 정확히 일치.
+---
+
+# Compose: 상태홀더 / UI 분리
+
+> 출처: chrisbanes/skills (Apache-2.0) · 벤더링 2026-06-09. 예시를 Caro의 Route/Screen + BaseViewModel 패턴으로 각색.
+> Caro 컨벤션 단일 출처: [`../_conventions/SKILL.md`](../_conventions/SKILL.md)
+
+## Caro 적용 노트
+
+이 스킬은 Caro의 **Route ↔ Screen 분리 규칙 그 자체**다.
+
+- **Route**(`<Name>Route.kt`): `viewModel.state.collectAsStateWithLifecycle()`, `LaunchedEffect`에서
+  `viewModel.sideEffect.collect { }`, `NavigationDispatcher.emit(...)`. 의존성·flow·네비게이션 담당.
+- **Screen**(`<Name>Screen.kt`): `@Composable internal fun XScreen(state: XState, onIntent: (XIntent) -> Unit)` —
+  순수 UI. ViewModel·flow·네비게이션 없음. 미리보기·테스트 가능해야 함.
+
+## Core principle
+
+상태홀더 배선과 UI 렌더링을 분리한다. 상태홀더 composable은 ViewModel·flow·네비게이션·side effect와 대화한다.
+UI composable은 plain 불변 상태 + 콜백을 받아 레이아웃을 기술한다. 화면을 미리보기·테스트·재사용(Android/iOS/CMP) 가능하게 한다.
+
+## 언제 쓰나
+
+Compose 화면이: ViewModel/component/navigator를 직접 받음, 레이아웃과 같은 함수에서 앱/비즈니스 상태나 effect를
+수집함, state holder 전체를 자식에 넘김, DI/네비게이션/lifecycle 때문에 미리보기 어려움, 단순 레이아웃 분기 검증에
+전체 앱 스택이 필요함.
+
+## 패턴 (Caro)
+
+```kotlin
+// Route: 상태홀더 배선
+@Composable
+fun ProfileRoute(viewModel: ProfileViewModel, navDispatcher: NavigationDispatcher) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is ProfileSideEffect.NavigateBack -> navDispatcher.emit(NavCommand.Back)
+            }
+        }
+    }
+
+    ProfileScreen(state = state, onIntent = viewModel::intent)
+}
+```
+
+```kotlin
+// Screen: 순수 UI (상태홀더를 모름)
+@Composable
+internal fun ProfileScreen(
+    state: ProfileState,
+    onIntent: (ProfileIntent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // 레이아웃만. CaroTheme 토큰, stringResource 사용.
+}
+```
+
+## 분리 규칙
+
+| 관심사 | Route(상태홀더) | Screen(UI) |
+|---|---|---|
+| ViewModel `state` 수집 | 예 | 아니오 |
+| 1회성 `sideEffect` 수집 | 예 | 보통 아니오 |
+| DI 객체 보유 | 예 | 아니오 |
+| 불변 UI 상태 수신 | 보통 통과 | 예 |
+| 사용자 이벤트 람다(`onIntent`) | 배선 | 호출 |
+| 레이아웃·modifier·semantics | 최소 | 예 |
+| UI-로컬 상태(스크롤·포커스·텍스트·애니메이션) | 가끔 seed | 예 |
+| 미리보기/스크린샷 친화 | 아닐 수 있음 | 예 |
+
+"UI composable에서 collect 금지"는 앱/비즈니스 상태·effect 스트림 얘기다. plain UI composable은
+`rememberScrollState`, `rememberLazyListState`, `FocusRequester`, `TextFieldState`, `MutableInteractionSource` 같은
+UI-로컬 프레임워크 상태는 여전히 가질 수 있다(예: `CaroTextField`).
+
+## 무엇을 넘길까
+
+- 진짜 상태가 있으면 여러 무관한 primitive보다 전용 `State` 객체(Caro의 `XState`).
+- component 전체 대신 명시적 람다(`onIntent`, `onRetryClick`).
+- UI에 비즈니스 규칙을 강제하는 도메인 모델은 UI 밖에. 필요하면 UI 모델로 매핑.
+- 네비게이션은 콜백/Intent로. UI는 "뒤로 가기 눌림"이라 말하고 "route X로 가라"가 아니다 → Caro에선 SideEffect → Route.
+
+## 흔한 실수
+
+| 실수 | 수정 |
+|---|---|
+| `fun Screen(viewModel: VM)`에 레이아웃 전부 | state + 콜백 받는 순수 UI overload 추가 (Caro: Route/Screen 분리) |
+| 자식 composable이 `viewModel`/`component`를 받음 | 필요한 state/콜백만 전달 |
+| UI composable이 네비게이션 실행 | `onXClick`/Intent 노출, Route에서 emit |
+| UI composable이 앱/비즈니스 flow를 collect | Route에서 수집해 값만 내려보냄 |
+| 모든 작은 composable에 상태홀더 overload | 화면/섹션 경계에서만 분리, 매 `Row`마다 X |
+
+## 적용 안 되는 경우
+
+- 이미 plain 값/콜백만 받는 작은 일회성 composable.
+- `Button`/`Card`/`CaroTextField` 같은 디자인시스템 primitive — 상태홀더가 아니라 슬롯·modifier를 노출
+  ([`../compose-slot-api-pattern/SKILL.md`](../compose-slot-api-pattern/SKILL.md)).
+
+## 관련
+
+- [`../compose-ui-testing-patterns/SKILL.md`](../compose-ui-testing-patterns/SKILL.md) — 순수 UI composable 테스트.
+- [`../compose-state-hoisting/SKILL.md`](../compose-state-hoisting/SKILL.md) — UI 상태/로직을 어디에 둘지.
+- [`../compose-side-effects/SKILL.md`](../compose-side-effects/SKILL.md) — Route의 effect 수집.
+- [`../_conventions/SKILL.md`](../_conventions/SKILL.md) — Caro Route/Screen 규칙.

--- a/.claude/skills/compose-ui-testing-patterns/SKILL.md
+++ b/.claude/skills/compose-ui-testing-patterns/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: compose-ui-testing-patterns
+description: >
+  Compose UI/상태홀더 동작 테스트(상태 분기, 콜백/Intent 배선, sideEffect 검증, semantics, 스크린샷)를
+  작성·리뷰할 때 사용한다. "UI 테스트", "ViewModel 테스트", "Compose 테스트", "Turbine", "Kotest로 테스트",
+  "상태 검증", "sideEffect 테스트" 맥락에서 발동. Caro의 Kotest + Mokkery + Turbine + KoinTest 스택에 맞춰 각색됨.
+---
+
+# Compose / 상태홀더 테스트 패턴
+
+> 출처: chrisbanes/skills (Apache-2.0) · 벤더링 2026-06-09. **JUnit/Espresso/Truth 예시를 Caro 스택
+> (Kotest FunSpec + KoinTest + Mokkery + Turbine + kotlinx-coroutines-test)로 전면 각색함.**
+> Caro 컨벤션 단일 출처: [`../_conventions/SKILL.md`](../_conventions/SKILL.md)
+
+## Caro 적용 노트
+
+- Caro의 **1차 테스트 대상은 ViewModel/상태**다(`feature/*/src/commonTest`). MVI 분기·상태 전이·sideEffect를
+  `commonTest`에서 검증하면 플랫폼 무관하게 빠르게 돈다.
+- 스택: **Kotest** `FunSpec` + `init { }`, **KoinTest**(`KoinExtension`), **Mokkery**(repository 모킹),
+  **Turbine**(`sideEffect`/flow), `StandardTestDispatcher` + `Dispatchers.setMain/resetMain` + `runTest`.
+- Compose `composeTestRule` UI 테스트는 Android instrumented 경로라 현재 기본 흐름이 아니다. 가능한 한 로직을
+  ViewModel/상태로 끌어내려 `commonTest`에서 검증하고, 진짜 레이아웃/시각 계약만 UI/스크린샷 테스트로.
+
+## Core principle
+
+동작을 증명하는 **가장 작은 계약**을 테스트한다. ViewModel 상태/sideEffect 테스트와 plain 상태기반 UI 테스트를
+선호한다. lifecycle·네비게이션·DI·플랫폼 동작 자체가 검증 대상일 때만 통합 테스트를 추가한다.
+
+## 테스트 대상 선택
+
+| 증명할 것 | 테스트 형태 |
+|---|---|
+| Intent → 상태 전이, 분기, 로딩/에러 상태 | **ViewModel 단위 테스트**(Kotest + Mokkery) |
+| 1회성 이벤트(네비게이션/토스트) 방출 | **ViewModel + Turbine**으로 `sideEffect` 검증 |
+| repository 호출/매핑 | repository/datasource 단위 테스트(Mokkery) |
+| 텍스트·버튼·로딩/에러 분기·조건부 content | plain UI Compose 테스트(`composeTestRule`, Android) |
+| 시각 레이아웃·타이포·elevation | 스크린샷 테스트 |
+| 네비게이션·lifecycle·DI 통합 | 통합 테스트 |
+
+## ViewModel 상태 테스트 (Caro 기본)
+
+`HomeViewModelTest` 패턴(`feature/home/src/commonTest/kotlin/HomeViewModelTest.kt`)을 따른다:
+
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+class LoginViewModelTest : FunSpec(), KoinTest {
+    init {
+        extensions(KoinExtension(listOf(loginModule, testDataModule)))
+        val dispatcher = StandardTestDispatcher()
+        beforeTest { Dispatchers.setMain(dispatcher) }
+        afterTest { Dispatchers.resetMain(); dispatcher.cancel() }
+
+        test("구글 로그인 성공 시 isLoading=false 로 끝난다") {
+            runTest {
+                val vm: LoginViewModel = get()
+                vm.intent(LoginIntent.ClickGoogleLoginButton(successResult))
+                advanceUntilIdle()
+                vm.state.value.isLoading shouldBe false
+            }
+        }
+    }
+}
+```
+
+핵심: `runTest { }` 안에서 `intent()` 호출 → `advanceUntilIdle()`로 `launch` 완료 대기 → `state.value` 단언.
+`shouldBe`(Kotest matcher) 사용.
+
+## sideEffect 검증 (Turbine)
+
+1회성 이벤트는 `state`에 없으므로 Turbine으로 flow를 검증한다:
+
+```kotlin
+test("로그인 성공 시 NavigateHome sideEffect 방출") {
+    runTest {
+        val vm: LoginViewModel = get()
+        vm.sideEffect.test {
+            vm.intent(LoginIntent.ClickGoogleLoginButton(successResult))
+            awaitItem() shouldBe LoginSideEffect.NavigateHome
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}
+```
+
+## repository 모킹 (Mokkery)
+
+```kotlin
+val authRepository = mock<AuthRepository> {
+    everySuspend { loginWithSocial(any(), any()) } returns fakeSession
+}
+// 호출 검증
+verifySuspend { authRepository.loginWithSocial(SocialLoginType.GOOGLE, any()) }
+```
+
+## Compose UI 테스트 (필요 시, Android)
+
+상태홀더/UI 분리가 돼 있으면 **plain UI composable(Screen)**을 테스트한다 — ViewModel·DI·네비게이션 구성 불필요:
+
+```kotlin
+composeTestRule.setContent {
+    CaroTheme {
+        ProfileScreen(
+            state = ProfileState(name = "Ada", canSave = true),
+            onIntent = { intent -> captured = intent },
+        )
+    }
+}
+composeTestRule.onNodeWithText("Ada").assertIsDisplayed()
+composeTestRule.onNodeWithText("저장").performClick()
+captured shouldBe ProfileIntent.ClickSave
+```
+
+- **semantics 우선**: `onNodeWithText`, `assertIsEnabled/assertIsNotEnabled`, `assertDoesNotExist`. 안정적 텍스트가
+  없을 때만 test tag.
+- **콜백/Intent는 캡처해 단언**: 노드 존재만이 아니라 콜백이 호출됐는지/상태가 바뀌었는지 확인.
+- **interaction 상태**(hover/press/focus)는 `MutableInteractionSource`를 주입해 `emit`. 포인터 이벤트 시뮬레이션 금지.
+- 문자열은 `stringResource(Res.string...)` 기반이므로 테스트에서도 리소스 키와 일치하는 실제 문자열로 단언.
+
+## 스크린샷 테스트
+
+semantics로 증명 못 하는 시각 계약(간격·테마 색·타이포·elevation)에만. 상태를 결정적으로 고정(고정 데이터,
+클록/애니메이션 고정, 네트워크/이미지 로딩은 fake).
+
+## 흔한 실수
+
+| 실수 | 수정 |
+|---|---|
+| 에러 행 테스트에 전체 앱 그래프 구성 | `state = Error`로 plain UI 테스트, 또는 ViewModel 단위 테스트 |
+| ViewModel mock을 통해 클릭 동작 테스트 | Intent/콜백을 넘기고 호출 단언 |
+| 단순 텍스트 존재에 스크린샷 | semantics 단언 |
+| 간격/색/focus ring에 semantics | 스크린샷 테스트 |
+| 곳곳에 test tag | 안정적이면 text/contentDescription 우선 |
+| `runBlocking`으로 코루틴 테스트 | `runTest` + `advanceUntilIdle` ([`../kotlin-coroutines-structured-concurrency/SKILL.md`](../kotlin-coroutines-structured-concurrency/SKILL.md)) |
+| `sideEffect`를 state 단언으로 검증 시도 | Turbine `sideEffect.test { awaitItem() }` |
+
+## 리뷰 시 위험 신호
+
+- 단순 렌더링에 production DI를 쓰는 테스트.
+- 액션 후 콜백/상태 변경이 아니라 노드 존재만 확인하는 단언.
+- `sideEffect` 방출을 검증하지 않고 네비게이션 동작을 "그냥 될 것"으로 가정.
+- `advanceUntilIdle()` 없이 `launch` 결과를 단언(레이스).
+- 스크린샷에 랜덤 날짜/시계/원격 이미지/라이브 데이터.
+
+## 관련
+
+- [`../compose-state-holder-ui-split/SKILL.md`](../compose-state-holder-ui-split/SKILL.md) — plain UI(Screen) 테스트 용이성.
+- [`../kotlin-flow-state-event-modeling/SKILL.md`](../kotlin-flow-state-event-modeling/SKILL.md) — state/sideEffect 모델.
+- [`../kotlin-coroutines-structured-concurrency/SKILL.md`](../kotlin-coroutines-structured-concurrency/SKILL.md) — runTest.
+- [`../_conventions/SKILL.md`](../_conventions/SKILL.md) — Kotest/Mokkery/Turbine 스택.

--- a/.claude/skills/kotlin-coroutines-structured-concurrency/SKILL.md
+++ b/.claude/skills/kotlin-coroutines-structured-concurrency/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: kotlin-coroutines-structured-concurrency
+description: >
+  CoroutineScope를 프로퍼티로 저장하거나, init/비-suspend API에서 launch 하거나, runBlocking을 쓰거나,
+  suspend 호출 주변에서 광범위 예외를 catch 하는 Kotlin 코드를 작성·리뷰할 때 사용한다.
+  "코루틴 스코프", "structured concurrency", "suspend로 바꿔", "runBlocking", "CancellationException",
+  "fire-and-forget", "스코프 어디에" 맥락에서 발동. Caro는 Repository=suspend, ViewModel=BaseViewModel.launch{} 규칙.
+---
+
+# Kotlin 코루틴: structured concurrency
+
+> 출처: chrisbanes/skills (Apache-2.0) · 벤더링 2026-06-09. 핵심 원칙을 유지하고 Android 전용 carve-out(ContentProvider/Hilt)은 축약, Caro 매핑을 추가함.
+> Caro 컨벤션 단일 출처: [`../_conventions/SKILL.md`](../_conventions/SKILL.md)
+
+## Caro 적용 노트
+
+- **Repository / DataSource는 `suspend` 함수만 노출한다.** `CoroutineScope`를 생성자에 받거나 프로퍼티로 저장하지 않는다.
+  (예: `AuthRepository.loginWithSocial(...)`는 `suspend`.)
+- **UI ↔ 상태홀더 경계는 `BaseViewModel.launch { }`이다.** ViewModel은 `intent()` → `handleIntent()`에서
+  `launch { repo.xxx(); reduce { copy(...) }; postSideEffect(...) }` 형태로 비-suspend UI 이벤트를 lifecycle 스코프 작업으로 번역한다.
+  이는 본 스킬 §3의 정당한 carve-out이다.
+- `BaseViewModel.launch`는 내부적으로 `viewModelScope.launch(context + coroutineExceptionHandler)`이므로
+  ViewModel에서 별도 스코프를 만들지 말 것. 공통 에러는 `handleClientException` 훅이 받는다.
+- 테스트는 `runBlocking`이 아니라 `runTest` + `StandardTestDispatcher`.
+
+## Core principle
+
+잘 구조화된 코루틴은 자족적인 비동기 작업 단위다 — 진입 하나, 종료 하나, 호출 지점에서 알려진 lifecycle에 묶임.
+
+**스코프는 대개 callee의 프로퍼티가 아니라 caller의 lifecycle에 묶여야 한다.** 저장된 `CoroutineScope`는
+강한 리뷰 신호다: 그 클래스가 취소·에러 보고·재시작·lifecycle을 소유함을 증명해야 한다. 대부분의 repository,
+manager, use case, data source는 그걸 증명할 수 없으므로 `suspend` API를 노출해야 한다.
+
+수정은 거의 항상 같다: **API를 `suspend`로 만들고 스코프는 caller가 소유하게 한다.**
+
+## 언제 쓰나
+
+Kotlin 코드를 작성·리뷰하다 다음을 볼 때:
+
+- `private val scope: CoroutineScope` (생성자 인자를 프로퍼티로 저장)
+- `init { scope.launch { ... } }`
+- 본문이 `scope.launch { ... }`인 비-suspend public 함수
+- suspend 가능한 앱 코드의 `runBlocking { ... }`, 또는 `runTest`를 써야 할 테스트의 `runBlocking`
+- `runCatching { suspendCall() }` 또는 suspend 호출 주변의 `Exception`/`Throwable` catch에서 `CancellationException` 미재전파
+- 취소를 재전파하지 않는 `catch (e: CancellationException)`
+
+## 조용한-취소 버그
+
+저장된 `CoroutineScope` 프로퍼티가 위험한 이유: **스코프가 한 번 취소되면 이후 그 위에서의 모든 `launch`는
+예외도 로그도 없이 조용히 취소로 완료된다.** 작업이 그냥 안 일어난다. 진단하기 가장 어려운 코루틴 버그.
+
+API가 `suspend`면 이 일은 불가능하다: caller의 스코프가 살아있거나(작업 실행) 호출 지점이 취소한다(caller가 안다).
+
+## 안티패턴과 수정
+
+### 1. 프로퍼티로 저장된 CoroutineScope
+
+```kotlin
+// ❌ BAD
+class AuthRepositoryImpl(
+    private val scope: CoroutineScope,
+    private val dataSource: RemoteAuthDataSource,
+) : AuthRepository {
+    fun refresh() { scope.launch { _state.value = dataSource.fetchUser() } }
+}
+
+// ✅ GOOD (Caro: repository는 suspend만)
+class AuthRepositoryImpl(
+    private val dataSource: RemoteAuthDataSource,
+) : AuthRepository {
+    override suspend fun refresh(): User = dataSource.fetchUser()
+}
+```
+
+Repository는 코루틴을 알 필요가 없다. 스코프·에러 처리·취소 시맨틱은 caller(ViewModel)가 정한다.
+
+### 2. init 블록 launch
+
+```kotlin
+// ❌ BAD: 생성 시점 부수효과, 무한 작업
+class UserSession(private val scope: CoroutineScope, private val ds: DataSource) {
+    init { scope.launch { _user.value = ds.load() } }
+}
+
+// ✅ GOOD: 명시적 부트스트랩, caller가 suspension 소유
+class UserSession(private val ds: DataSource) {
+    private var _user: User? = null
+    val user: User get() = checkNotNull(_user) { "Call init() first" }
+    suspend fun init() { _user = ds.load() }
+}
+```
+
+### 3. 비-UI 클래스의 fire-and-forget
+
+비-UI 클래스(repository, manager, use case, data source)의 비-suspend public 함수가 클래스 소유 스코프로
+launch 하는 것. caller는 결과·에러·취소를 못 받고 작업이 실행됐는지도 보장 못 한다 → `suspend`로 바꾼다.
+
+#### Carve-out: UI ↔ 상태홀더 경계 (Caro의 BaseViewModel)
+
+UI 프레임워크는 비-suspend다. Composable의 `onClick`은 suspend 불가. **상태홀더(Caro의 `BaseViewModel`)**가
+1회성 UI 이벤트를 UI lifecycle에 묶인 비동기 작업으로 번역하는 경계다 — 그게 그 역할이다.
+
+```kotlin
+// ✅ GOOD — BaseViewModel이 비-suspend UI 이벤트를 자기 스코프로 흡수
+class LoginViewModel(private val authRepository: AuthRepository) :
+    BaseViewModel<LoginState, LoginIntent, LoginSideEffect>(LoginState()) {
+
+    private fun requestLogin(provider: SocialLoginType, idToken: String) {
+        launch {                                  // viewModelScope + 공통 예외 핸들러
+            authRepository.loginWithSocial(provider, idToken)
+            postSideEffect(LoginSideEffect.NavigateHome)
+        }
+    }
+}
+```
+
+세 조건이 모두 성립할 때만 carve-out이다: (1) UI surface의 상태홀더, (2) lifecycle 묶인 스코프(`viewModelScope`),
+(3) caller가 진짜 UI 이벤트. Repository/manager가 상태홀더를 통해 호출하는 건 해당 안 됨.
+
+### 4. 주입되지 않고 내부 생성된 스코프
+
+```kotlin
+// ❌ BAD — 내부 생성 저장 스코프
+class FooManager {
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+}
+```
+
+lifecycle 소유자가 없고 영원히 산다. `suspend` API로 교체.
+
+### 5. DI 바인딩 싱글톤/이니셜라이저가 launch
+
+DI 바인딩 클래스가 생성자/`init`에서 코루틴을 launch 하면: 시작 시점 비결정적, lifecycle 관측 불가,
+stop/restart 경로 없음, launch 지점 grep 불가. 
+
+먼저 물어라: **이 백그라운드 루프 클래스가 존재할 필요가 있나?** 대개는 관측을 소비자 쪽으로 뒤집으면(Pattern 1)
+클래스 자체가 사라진다. 정말 주기적이면 스케줄 작업(Pattern 2), 동기 API가 호출해오면 명시적 named launch 지점(Pattern 3).
+`init`/`initialize()`에서 launch 하지 말 것. (이니셜라이저는 *등록*만 해야 한다.)
+
+### 6. CancellationException 삼키기
+
+suspend 호출 주변 `catch`가 `CancellationException`을 (직접 또는 `Exception`/`Throwable`로) 매치하고
+재전파 안 하면, 보통 취소를 조용한 성공으로 바꾼다.
+
+```kotlin
+// ❌ BAD — CancellationException도 잡고 재전파 안 함
+try { ds.load() } catch (e: Exception) { Napier.w { "load failed" } }
+
+// ✅ 분리 catch
+try { ds.load() }
+catch (e: CancellationException) { throw e }
+catch (e: Exception) { Napier.w { "load failed" } }
+
+// ✅ 광범위 catch 안에서 조건부 재전파
+try { ds.load() }
+catch (e: Exception) {
+    if (e is CancellationException) throw e
+    Napier.w { "load failed" }
+}
+
+// ✅ ensureActive()
+try { ds.load() }
+catch (e: Exception) { currentCoroutineContext().ensureActive(); Napier.w { "load failed" } }
+```
+
+> Caro의 `BaseViewModel.launch`는 `coroutineExceptionHandler`를 달고 있어 일반 실패는 `handleClientException`로
+> 흘려보낸다. 그래도 명시적 `try/catch`를 쓸 땐 `CancellationException`을 반드시 재전파할 것.
+
+비-취소 서브타입(`IOException`, 자체 예외) catch는 괜찮다 — `CancellationException`을 상속하지 않는다.
+
+### 7. runBlocking
+
+`runBlocking`은 람다가 끝날 때까지 스레드를 멈춘다. suspend 가능/lifecycle 스코프 앱 경로에선 틀렸다.
+
+```kotlin
+// ❌ BAD — 호출 스레드를 막아 suspend로 다리 놓기
+fun saveUser(user: User) { runBlocking { repository.save(user) } }
+
+// ✅ GOOD — 함수를 suspend로
+suspend fun saveUser(user: User) = repository.save(user)
+```
+
+테스트는 `runBlocking` 대신 `runTest`(가상 시간, `TestDispatcher`, 적절한 정리). 
+
+> Caro 참고: Android의 `ContentProvider` carve-out 같은 동기 프레임워크 경계는 이 KMP 앱의 commonMain 코드와
+> 무관하다. 불가피한 동기 경계가 생기면 본문을 최소화하고 즉시 suspend 코드로 진입.
+
+## Quick reference
+
+| 증상 | 안티패턴 | 수정 |
+|---|---|---|
+| 클래스가 `private val scope: CoroutineScope` | 저장 스코프 | 제거, public API를 `suspend`로 |
+| `init { scope.launch { ... } }` | 생성 시점 launch | `suspend fun init()`으로 이동 |
+| repository/manager에서 `fun foo() { scope.launch {...} }` | 비-UI fire-and-forget | `suspend fun foo()`, UI 상태홀더가 스코프 선택 |
+| `BaseViewModel`에서 `fun onClick() { launch {...} }` | UI↔상태홀더 경계 | 그대로 유지 (§3 carve-out) |
+| `try { suspendCall() } catch(Exception) {}` 재전파 없음 | 취소 삼킴 (§6) | `catch (e: CancellationException) { throw e }` 우선 |
+| 앱 코드 `runBlocking { ... }` | 스레드 차단 다리 (§7) | caller를 `suspend`로 |
+| 테스트 `runBlocking { ... }` | 실시간 다리 (§7) | `runTest { ... }` |
+
+## When NOT to apply
+
+- **UI 이벤트를 흡수하는 상태홀더**(Caro `BaseViewModel`의 `launch`) — 정상.
+- **명시적 취소/에러 정책을 가진 lifecycle 소유자** — `close`/`cancel`/restart를 노출하면 스코프 소유 가능. 단 `init`에서 launch는 아님.
+- **이미 suspend인 API**.
+- **테스트의 의도적 `TestScope`**.
+
+## 리뷰 시 위험 신호
+
+| 생각 | 현실 |
+|---|---|
+| "스코프에 `CoroutineExceptionHandler`만 달면 돼" | 문제는 에러 처리가 아니라 스코프가 존재하면 안 된다는 것. |
+| "데이터 준비되게 init에서 launch 해야 해" | 준비 안 된 상태를 읽는 게 버그. phasing 사용. |
+| "caller가 suspend 다루기 싫어해" | 그럼 caller가 자기 스코프에서 fire-and-forget 선택. 대신 결정하지 말 것. |
+| "작은 fire-and-forget일 뿐" | 조용한 취소는 모든 fire-and-forget을 잠재적 조용한 실패로 만든다. |
+| "잡아서 로그했으니 괜찮아" | `CancellationException`을 재전파했나? 아니면 조용히 취소 해제됨. (§6) |
+
+## 관련
+
+- [`../kotlin-flow-state-event-modeling/SKILL.md`](../kotlin-flow-state-event-modeling/SKILL.md) — StateFlow/SharedFlow/Channel, 1회성 이벤트.
+- [`../compose-side-effects/SKILL.md`](../compose-side-effects/SKILL.md) — Compose에서 effect/flow 수집.
+- [`../_conventions/SKILL.md`](../_conventions/SKILL.md) — BaseViewModel.launch / Repository suspend 규칙.

--- a/.claude/skills/kotlin-flow-state-event-modeling/SKILL.md
+++ b/.claude/skills/kotlin-flow-state-event-modeling/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: kotlin-flow-state-event-modeling
+description: >
+  StateFlow, MutableStateFlow.update, SharedFlow, Channel, stateIn, SharingStarted, .value,
+  receiveAsFlow, 1회성 이벤트, sentinel 초기값 등 Kotlin Flow 상태/이벤트 API를 작성·리뷰할 때 사용한다.
+  "StateFlow", "SharedFlow", "Channel", "1회성 이벤트", "navigation 이벤트", "sentinel/placeholder 상태",
+  "update vs value", "stateIn" 맥락에서 발동. Caro는 state=MutableStateFlow, sideEffect=Channel(BUFFERED) 패턴.
+---
+
+# Kotlin Flow: 상태/이벤트 모델링
+
+> 출처: chrisbanes/skills (Apache-2.0) · 벤더링 2026-06-09. 원문 유지 + Caro(BaseViewModel) 매핑 추가.
+> Caro 컨벤션 단일 출처: [`../_conventions/SKILL.md`](../_conventions/SKILL.md)
+
+## Caro 적용 노트
+
+`BaseViewModel`이 이미 올바른 선택을 내장한다:
+
+- **상태**: `private val _state = MutableStateFlow(initial); val state = _state.asStateFlow()` — 항상 값이 있고 동기 `.value` 가능.
+- **1회성 이벤트**: `private val _sideEffect = Channel<SE>(capacity = BUFFERED, onBufferOverflow = SUSPEND); val sideEffect = _sideEffect.receiveAsFlow()` — 정확히-한-소비자(Route) 핸드오프. **이것이 본 스킬이 권장하는 패턴이다.** 네비게이션/토스트에 `SharedFlow`를 새로 쓰지 말 것.
+- 상태 변경은 `reduce { copy(...) }`. (아래 `update { }` 원칙과 동일 정신 — read/modify/write 직접 대입 회피.)
+
+## Core principle
+
+**replay·fan-out·동기 읽기 요구에 맞는 primitive를 고른다.** `StateFlow`, `SharedFlow`, `Channel` 기반 flow,
+cold `Flow`는 버퍼링·누가 각 emission을 보는가·`.value` 존재 여부가 다르다. 잘못 고르면 이벤트를 잃거나,
+sharing 코루틴을 누수하거나, 가짜 도메인 sentinel을 상태에 강제한다.
+
+## 1회성 이벤트엔 SharedFlow보다 Channel
+
+`SharedFlow` 기본값은 replay 버퍼가 없다. emission 순간에 아무도 collect 안 하면 이벤트는 사라진다.
+**단일 UI 소비자**의 정확히-한-번 이벤트(네비게이션/스낵바)엔 버퍼드 `Channel`을 Flow로 노출하는 게 더 맞다:
+
+```kotlin
+// ❌ BAD
+private val _navEvents = MutableSharedFlow<NavigationEvent>()
+val navEvents: SharedFlow<NavigationEvent> = _navEvents.asSharedFlow()
+
+// ✅ GOOD (Caro의 BaseViewModel.sideEffect가 정확히 이 형태)
+private val _navEvents = Channel<NavigationEvent>(Channel.BUFFERED)
+val navEvents: Flow<NavigationEvent> = _navEvents.receiveAsFlow()
+```
+
+`Channel.receiveAsFlow()`는 **fan-out(브로드캐스트 아님)**: 여러 collector면 각 이벤트는 하나에게만 간다.
+모든 관찰자가 같은 이벤트를 봐야 하면 명시적 상태나 의도적으로 설정한 `SharedFlow`를 쓴다.
+
+## sentinel 기본값으로 오염된 StateFlow
+
+`StateFlow`는 초기값을 강제한다. 실제 값이 비동기일 때 가짜 도메인 값(`NoUser`, placeholder ID)을 만들면
+모든 소비자가 그 sentinel을 진짜 데이터로 다뤄야 한다. → 부재/로딩/에러가 진짜 상태면 명시적으로 모델링
+(`User?`, `sealed interface UiState`), 아니면 phasing(실제 값이 생길 때까지 노출 안 함).
+
+## update { } 로 변경
+
+`.value`를 읽고 다시 쓰는 대신 `MutableStateFlow.update { current -> ... }`를 선호한다. 여러 코루틴이 같은 상태를
+변경할 때 lost update를 막는다.
+
+```kotlin
+// BAD — read/modify/write
+_state.value = _state.value.copy(selectedId = id, details = details)
+
+// GOOD — 최신 상태에서 변환
+_state.update { it.copy(selectedId = id, details = details) }
+```
+
+update 람다는 재시도될 수 있으니, 현재 상태에 의존하지 않는 비싼 객체 생성은 블록 밖에서 한다.
+
+> Caro 참고: ViewModel 안에서는 `reduce { copy(...) }`를 쓴다(`BaseViewModel`이 단일 변경 경로를 제공).
+> repository/세션 등 ViewModel 밖의 `MutableStateFlow`에는 위 `update { }` 규칙을 직접 적용한다.
+
+## 함수 안의 stateIn()
+
+```kotlin
+// ❌ BAD — 호출마다 새 sharing 코루틴
+fun getPreferences(): StateFlow<Prefs> =
+    repo.prefsFlow.stateIn(scope, SharingStarted.Eagerly, Prefs.Default)
+
+// ✅ GOOD — 한 번 계산되는 공유 인스턴스
+val preferences: StateFlow<Prefs> =
+    repo.prefsFlow.stateIn(viewModelScope, SharingStarted.Eagerly, Prefs.Default)
+```
+
+## WhileSubscribed + 동기 .value
+
+`WhileSubscribed(timeout)`는 활성 collector가 없으면 upstream을 끊고, 그동안 `.value`는 stale일 수 있다.
+`.value`가 항상 신선해야 하면 `SharingStarted.Eagerly`나 명시적 초기화. stale/cached가 허용될 때만 `WhileSubscribed`.
+
+## StateFlow.map 은 .value 를 잃는다
+
+```kotlin
+// ❌ BAD — 이제 평범한 Flow, name.value 컴파일 안 됨
+val name: Flow<String> = userState.map { it.name }
+
+// ✅ GOOD — .stateIn 으로 종료
+val name: StateFlow<String> = userState.map { it.name }
+    .stateIn(viewModelScope, SharingStarted.Eagerly, userState.value.name)
+```
+
+## 결정: 어떤 Flow 타입?
+
+| 필요 | primitive |
+|------|-----------|
+| 항상 값이 있고, 비동기 collector와 동기 코드 둘 다 읽음 | `StateFlow` (`.value` 중요하면 `Eagerly`) |
+| hot 스트림, 다중 구독, 동기 `.value` 불필요 | `SharedFlow` |
+| 한 소비자, 정확히-한-번 핸드오프 | `Channel(BUFFERED).receiveAsFlow()` (Caro sideEffect) |
+| cold 스트림, collect마다 한 소비자 | 평범한 `Flow` |
+
+## Quick reference
+
+| 증상 | 문제 | 수정 |
+|---------|---------|-----|
+| `MutableStateFlow<X>(FakeDomainValue)` | 잘못된 placeholder 기본값 | 부재 명시 모델링 / phasing |
+| 단일소비자 nav/snackbar에 `MutableSharedFlow` | 손실 가능 이벤트 스트림 | `Channel(BUFFERED).receiveAsFlow()` |
+| `fun foo() = flow.stateIn(...)` | 호출마다 sharing 코루틴 | `val`/공유 인스턴스로 |
+| `WhileSubscribed` + 신선해야 하는 `.value` | stale/초기 데이터 | `Eagerly`/명시 초기화 |
+| `stateFlow.map { }`를 상태로 소비 | `.value` 상실 | `.stateIn(...)`으로 종료 |
+| `_state.value = _state.value.copy(...)` | 비원자적 RMW | `update { it.copy(...) }` (ViewModel은 `reduce`) |
+
+## 리뷰 시 위험 신호
+
+| 생각 | 현실 |
+|---------|---------|
+| "구독자가 여럿이라 SharedFlow가 필요해" | 다중 구독자는 시맨틱을 바꾼다. `Channel.receiveAsFlow()`는 브로드캐스트 아님. 의도적으로 선택. |
+| "리소스 아끼려 WhileSubscribed 쓸래" | stale/초기 `.value`가 허용될 때만. 먼저 확인. |
+| "데이터 로드 전까지 sentinel 쓸래" | 소비자가 진짜 도메인으로 취급. 명시 모델링/phasing 선호. |
+
+## 관련
+
+- [`../kotlin-coroutines-structured-concurrency/SKILL.md`](../kotlin-coroutines-structured-concurrency/SKILL.md) — 스코프 소유, 취소, runBlocking.
+- [`../compose-side-effects/SKILL.md`](../compose-side-effects/SKILL.md) — Compose에서 이벤트 flow 수집.
+- [`../compose-state-holder-ui-split/SKILL.md`](../compose-state-holder-ui-split/SKILL.md) — 상태홀더가 UI에 flow를 노출하는 지점.
+- [`../_conventions/SKILL.md`](../_conventions/SKILL.md) — BaseViewModel state/sideEffect 형태.

--- a/.claude/skills/kotlin-multiplatform-expect-actual/SKILL.md
+++ b/.claude/skills/kotlin-multiplatform-expect-actual/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: kotlin-multiplatform-expect-actual
+description: >
+  KMP에서 플랫폼 서비스·네이티브 SDK·소스셋·Compose Multiplatform UI·권한·파일·설정·센서 등의
+  expect/actual 또는 인터페이스 경계를 설계할 때 사용한다. "expect/actual", "플랫폼 분기",
+  "iOS/Android 구현 분리", "commonMain에 어떻게", "actual 구현", "플랫폼 인터페이스" 맥락에서 발동.
+  Caro는 commonMain 공용 API + androidMain/iosMain actual(`*.android.kt`/`*.ios.kt`) 패턴을 쓴다.
+---
+
+# KMP: expect/actual 경계
+
+> 출처: chrisbanes/skills (Apache-2.0) · 벤더링 2026-06-09. 원문 기술 내용을 유지하되 Caro 컨벤션 노트를 추가함.
+> Caro 컨벤션 단일 출처: [`../_conventions/SKILL.md`](../_conventions/SKILL.md)
+
+## Caro 적용 노트
+
+- 플랫폼 분기는 `expect`/`actual` + 파일명 규칙 **`Foo.android.kt` / `Foo.ios.kt`** (`commonMain`에 `expect`).
+  실제 예: `core/remote/.../network/HttpClientEngineProvider.{kt, android.kt, ios.kt}` (OkHttp / Darwin).
+- iOS 라이브러리는 SPM4KMP로 통합한다(최근 마이그레이션됨). 네이티브 SDK는 actual 안에 숨기고 commonMain엔 의미적 API만 노출.
+- DI·테스트 페이크·런타임 선택이 필요하면 `expect class`가 아니라 **commonMain 인터페이스 + Koin 플랫폼 바인딩**을 쓴다
+  (Caro는 Koin 단축 DSL — [`../_conventions/SKILL.md`](../_conventions/SKILL.md) 참고).
+
+## Core principle
+
+공용(common) API는 의미적(semantic)이고 안정적으로 유지한다. 플랫폼 메커니즘은 작은 `expect`/`actual`
+선언이나 인터페이스 뒤에 숨기고, Android/iOS/Desktop 세부사항을 `commonMain` 밖으로 내보낸다.
+
+## 언제 쓰나
+
+공용 코드가 다음을 필요로 할 때:
+
+- 권한, 설정, 공유 시트, 딥링크, 햅틱, 생체인증, 클립보드.
+- 파일, 경로, 시계, 로케일, 네트워크 도달성, 센서, 암호화, 미디어, 카메라, 네이티브 SDK.
+- 네이티브 뷰/컨트롤러, Compose Multiplatform interop.
+- Android/iOS에서 구현은 다르지만 호출 지점은 하나로 공유하고 싶을 때.
+- `expect/actual` vs DI vs 인터페이스 vs 분리된 플랫폼 코드 사이의 선택.
+
+## 경계 고르기
+
+| 상황 | 선호 |
+|---|---|
+| 단순 컴파일타임 플랫폼 특수화 | `expect`/`actual` 함수·값·typealias·leaf composable |
+| 주입 의존성·생명주기 소유·런타임 선택·테스트 페이크가 필요 | commonMain 인터페이스 + 플랫폼 바인딩 |
+| UI 대부분 공유, 한 leaf만 다름 | `expect` leaf를 호출하는 공용 composable |
+| 화면 전체가 플랫폼별로 다름 | 공용 네비게이션 계약 뒤의 분리된 플랫폼 화면 |
+| 상수/리소스만 다름 | 의미적 값을 노출하는 공용 API, 플랫폼별 actual 값 |
+
+## 공용 API는 의미적으로
+
+공용 코드는 플랫폼이 *어떻게* 하는지가 아니라 제품이 *무엇*을 필요로 하는지 기술한다:
+
+```kotlin
+// GOOD: 의미적 공용 API
+expect fun currentRegion(): Region
+
+// BAD: Android 구현이 새어나옴
+expect fun currentRegionFromAndroidLocale(context: Context): Region
+```
+
+Android actual은 `Locale` API를, iOS actual은 Foundation API를 써도 된다. 호출자는 몰라야 한다.
+
+## actual은 얇게
+
+actual 구현은 의미적 API를 플랫폼 호출로 번역만 한다. Activity, view controller, 생명주기 소유자, DI,
+페이크가 필요하면 `expect class` 대신 **플랫폼이 공급하는 인터페이스**를 선호한다:
+
+```kotlin
+// commonMain
+interface ShareSheet {
+    suspend fun shareText(text: String)
+}
+```
+
+```kotlin
+// androidMain (ShareSheet.android.kt 등)
+class AndroidShareSheet(
+    private val activity: Activity,
+) : ShareSheet {
+    override suspend fun shareText(text: String) {
+        val intent = Intent(Intent.ACTION_SEND)
+            .setType("text/plain")
+            .putExtra(Intent.EXTRA_TEXT, text)
+        activity.startActivity(Intent.createChooser(intent, null))
+    }
+}
+```
+
+actual에 비즈니스 규칙이 쌓이기 시작하면, 그 규칙을 공용 코드로 옮기고 actual에는 플랫폼 번역만 남긴다.
+
+## 테스트/DI가 중요하면 인터페이스
+
+단순 컴파일타임 플랫폼 API엔 `expect/actual`. 공용 코드가 페이크·복수 구현·런타임 선택·생명주기 소유를
+필요로 하면 인터페이스:
+
+```kotlin
+interface Clipboard {
+    suspend fun setText(text: String)
+}
+```
+
+플랫폼 모듈이 `Clipboard`를 Android/iOS 구현에 바인딩한다(Caro에선 Koin). 공용 테스트는 페이크를 쓴다.
+
+## Compose 관련 가이드
+
+- 플랫폼별 Composable은 leaf 노드에 둔다.
+- UI를 그리는 모든 expect Composable에 `Modifier`를 통과시킨다.
+- `commonMain` 시그니처에 플랫폼 타입 금지(`Context`, `Activity`, 리소스 ID, `Uri`, `Bundle`,
+  `UIViewController`, `NSBundle`, 플랫폼 권한 enum 등).
+- 네이티브 뷰 생명주기가 중요하면 actual 안에 숨기고 알맞은 interop 컨테이너(`AndroidView`, `UIKitView`) 사용.
+- Composable 본문에서 플랫폼 작업을 직접 실행하지 말 것. actual Composable에서도 `remember`,
+  `LaunchedEffect`, `DisposableEffect`, 안정적 key를 공용 Compose와 똑같이 쓴다.
+- 미리보기/테스트는 페이크 플랫폼 서비스를 주입한 공용 plain composable로.
+
+## 흔한 실수
+
+| 실수 | 수정 |
+|---|---|
+| `commonMain` API가 Android/iOS 타입 노출 | 의미적 공용 타입으로 교체 |
+| `expect` 함수가 한 플랫폼 전용 파라미터를 가짐 | 그 세부사항을 actual로 이동 |
+| 비즈니스 분기가 각 actual에 중복 | 비즈니스 규칙을 공용 코드로 이동 |
+| 거대한 단일 `Platform` expect object | 기능별로 분리: `Clipboard`, `ShareSheet`, `Haptics` |
+| 플랫폼 UI가 트리 상단에 노출 | 플랫폼별 Composable을 leaf로 밀기 |
+| 공용 테스트용 페이크 경계 없음 | 직접 `expect` 호출 대신 인터페이스 |
+
+## 리뷰 시 위험 신호
+
+- 공용 코드가 플랫폼 패키지를 import 한다.
+- actual 구현이 제품 상태·네비게이션 결정·도메인 규칙을 안다.
+- 플랫폼 API 이름이 공용 함수 이름에 등장한다.
+- 세 번째 플랫폼을 추가하려면 공용 호출자를 바꿔야 한다.
+- 공용 비즈니스 동작 검증에 Android/iOS 런타임이 필요하다.
+
+## 관련
+
+- [`../compose-state-holder-ui-split/SKILL.md`](../compose-state-holder-ui-split/SKILL.md) — 공용 plain UI vs 상태홀더 배선.
+- [`../compose-side-effects/SKILL.md`](../compose-side-effects/SKILL.md) — actual composable의 effect key/cleanup.
+- [`../compose-slot-api-pattern/SKILL.md`](../compose-slot-api-pattern/SKILL.md) — 재사용 가능한 공용 Compose API(슬롯).
+- [`../_conventions/SKILL.md`](../_conventions/SKILL.md) — Caro 모듈/파일명/DI 규칙.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,5 @@
 이 저장소의 에이전트(Codex 등) 가이드는 [`CLAUDE.md`](./CLAUDE.md)를 참조합니다.
 
 `CLAUDE.md`를 단일 진실 공급원(single source of truth)으로 사용하며, 프로젝트 개요·빌드 커맨드·아키텍처·컨벤션 플러그인·테스트·CI 등 모든 가이드라인은 해당 문서에 정리되어 있습니다.
+
+작업 맥락(Compose/MVI/KMP/리뷰 등)에 맞는 절차서가 필요하면, `CLAUDE.md`의 **Skill(All Agents)** 섹션에 정리된 트리거-`SKILL.md` 매핑을 따릅니다. Codex용 별도 규칙은 두지 않으며, 목록을 여기 중복하지 않고 `CLAUDE.md`와 `.claude/skills`를 기준으로 합니다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,5 +208,27 @@ Claude 외의 에이전트(Codex 등)는 자동 발견을 못 하므로, 아래 
       사내 규칙 적용 후 변경 시 브랜치 + 커밋까지.
     - 실행 스크립트: `scripts/*.sh`(mac/Linux), `scripts/*.ps1`(Windows)
 
+- **_conventions** → [`.claude/skills/_conventions/SKILL.md`](./.claude/skills/_conventions/SKILL.md)
+    - 트리거: "우리 컨벤션", "모듈 구조", "MVI 구조", "화면 추가 절차"
+    - 내용: Caro 아키텍처 규칙 요약(모듈 의존·MVI·BaseViewModel·Koin·Navigation3·Compose
+      resources·expect-actual·Kotest). 아래 컴포즈/코틀린 스킬이 "우리 컨벤션은?"의 근거로 삼는다.
+
+- **caro-compose-review** → [`.claude/skills/caro-compose-review/SKILL.md`](./.claude/skills/caro-compose-review/SKILL.md)
+    - 트리거: "컴포즈 리뷰", "Compose 리뷰", "UI 리뷰", "MVI 리뷰", "상태/사이드이펙트 점검"
+    - 내용: PR/diff를 `_conventions` 기반 체크리스트(A~K)로 점검. 일반 버그 리뷰와 보완 관계.
+
+- **Compose/Kotlin/KMP 스킬** (코딩·리뷰 중 해당 주제가 나오면 그 디렉토리의 `SKILL.md`를 읽고 따른다)
+    - `kotlin-multiplatform-expect-actual` — "expect/actual", "플랫폼 분기", "commonMain 경계"
+    - `kotlin-coroutines-structured-concurrency` — "코루틴 스코프", "취소", "runBlocking"
+    - `kotlin-flow-state-event-modeling` — "StateFlow vs Channel", "이벤트 모델링", "sideEffect"
+    - `compose-state-authoring` — "remember", "mutableStateOf", "상태 작성"
+    - `compose-state-hoisting` — "상태 끌어올리기", "state hoisting", "remember 어디"
+    - `compose-state-holder-ui-split` — "Route/Screen 분리", "상태홀더", "순수 UI"
+    - `compose-side-effects` — "LaunchedEffect", "DisposableEffect", "부수효과"
+    - `compose-recomposition-performance` — "리컴포지션", "성능", "안정성"
+    - `compose-slot-api-pattern` — "슬롯 API", "재사용 컴포넌트", "디자인시스템 컴포넌트"
+    - `compose-ui-testing-patterns` — "UI 테스트", "ViewModel 테스트", "Turbine"
+    - 개요·출처: [`.claude/skills/README.md`](./.claude/skills/README.md)
+
 ## Creating Rule
 Remote data source implementation classes should carry a `Remote` prefix when the interface name is generic enough to be confused with repository/data-layer types (e.g., `RemoteProfileDataSourceImpl : ProfileDataSource`).


### PR DESCRIPTION
## 왜
코드 짤 때 Compose/Kotlin Best Practice대로 생성되게 유도하고, 리뷰에도 쓰려고 `.claude/skills`에 공유 스킬을 추가했어요.

## 뭐가 들어갔나
- chrisbanes/skills 중 KMP·Compose Multiplatform에 맞는 것만 골라서, 예시 코드를 우리 컨벤션으로 다시 썼어요.
- `caro-compose-review`: PR/diff를 우리 컨벤션 체크리스트로 보는 리뷰 스킬 (`/caro-compose-review`, 기존 `code-review` 보완)

스킬: expect-actual / coroutines / flow-state-event / state-authoring·hoisting·holder-split / side-effects / recomposition-performance / slot-api / ui-testing.

## 봐주실 점
트리거 문구나 범위 이 정도면 될지, stable 관련만 더 넣는 게 나을지 의견 주세요 🙏

## 작업한 내용
- `.claude/skills` 스킬 운영 문서 추가 (README.md)
- Caro-Mobile 프로젝트 아키텍처/컨벤션 통합 문서 추가 (_conventions/SKILL.md)
- PR/diff 리뷰 스킬 추가 (caro-compose-review/SKILL.md)
- Compose 관련 스킬 9개 추가
  - State authoring, hoisting, holder-UI split
  - Side effects, slot API pattern, recomposition performance
  - UI testing patterns
- Kotlin 관련 스킬 2개 추가
  - Coroutines structured concurrency
  - Flow state-event modeling
- KMP 관련 스킬 1개 추가
  - expect/actual 가이드