### PR TITLE
[Refactor] 프로필 화면 컨벤션 정합성 수정 및 ViewModel 테스트 추가

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/whatever/caro/composeApp/di/NavigationModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/whatever/caro/composeApp/di/NavigationModule.kt
@@ -7,7 +7,7 @@ import com.whatever.caro.core.navigator.entries.SplashEntry
 import com.whatever.caro.feature.home.HomeViewModel
 import com.whatever.caro.feature.home.route.HomeRoute
 import com.whatever.caro.feature.login.LoginRoute
-import com.whatever.caro.feature.profile.CreateProfileRoute
+import com.whatever.caro.feature.profile.route.CreateProfileRoute
 import com.whatever.caro.feature.splash.route.SplashRoute
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.KoinExperimentalAPI

--- a/feature/profile/src/commonMain/kotlin/com/whatever/caro/feature/profile/di/ProfileModule.kt
+++ b/feature/profile/src/commonMain/kotlin/com/whatever/caro/feature/profile/di/ProfileModule.kt
@@ -2,19 +2,12 @@ package com.whatever.caro.feature.profile.di
 
 import com.whatever.caro.feature.profile.CreateProfileViewModel
 import com.whatever.caro.feature.profile.NicknameValidator
-import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 import org.koin.plugin.module.dsl.single
+import org.koin.plugin.module.dsl.viewModel
 
 val profileModule =
     module {
         single<NicknameValidator>()
-
-        viewModel<CreateProfileViewModel> {
-            CreateProfileViewModel(
-                authRepository = get(),
-                profileRepository = get(),
-                nicknameValidator = get(),
-            )
-        }
+        viewModel<CreateProfileViewModel>()
     }

--- a/feature/profile/src/commonMain/kotlin/com/whatever/caro/feature/profile/route/CreateProfileRoute.kt
+++ b/feature/profile/src/commonMain/kotlin/com/whatever/caro/feature/profile/route/CreateProfileRoute.kt
@@ -1,4 +1,4 @@
-package com.whatever.caro.feature.profile
+package com.whatever.caro.feature.profile.route
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -6,6 +6,8 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.whatever.caro.core.navigator.contract.NavCommand
 import com.whatever.caro.core.navigator.dispatcher.NavigationDispatcher
+import com.whatever.caro.feature.profile.CreateProfileScreen
+import com.whatever.caro.feature.profile.CreateProfileViewModel
 import com.whatever.caro.feature.profile.mvi.CreateProfileSideEffect
 
 @Composable

--- a/feature/profile/src/commonTest/kotlin/CreateProfileViewModelTest.kt
+++ b/feature/profile/src/commonTest/kotlin/CreateProfileViewModelTest.kt
@@ -38,7 +38,6 @@ class CreateProfileViewModelTest : FunSpec() {
             dispatcher.cancel()
         }
 
-        // init 의 fetchRandomNickname 이 항상 닉네임을 채우도록 기본 스텁을 준 VM 팩토리.
         fun createViewModel(
             randomNickname: String = "기본닉네임",
             isAvailable: Boolean = true,
@@ -78,7 +77,6 @@ class CreateProfileViewModelTest : FunSpec() {
                 advanceUntilIdle()
 
                 viewModel.state.value.validationResult shouldBe NicknameValidationResult.TooShort
-                // 형식 검증 실패 시 가용성 API 를 호출하지 않아야 한다.
                 verifySuspend(exactly(0)) { profileRepository.isNicknameAvailable("a") }
             }
         }

--- a/feature/profile/src/commonTest/kotlin/CreateProfileViewModelTest.kt
+++ b/feature/profile/src/commonTest/kotlin/CreateProfileViewModelTest.kt
@@ -1,0 +1,148 @@
+import app.cash.turbine.test
+import com.whatever.caro.core.data.repository.AuthRepository
+import com.whatever.caro.core.data.repository.profile.ProfileRepository
+import com.whatever.caro.core.model.auth.AuthSession
+import com.whatever.caro.feature.profile.CreateProfileViewModel
+import com.whatever.caro.feature.profile.NicknameValidationResult
+import com.whatever.caro.feature.profile.NicknameValidator
+import com.whatever.caro.feature.profile.mvi.CreateProfileIntent
+import com.whatever.caro.feature.profile.mvi.CreateProfileSideEffect
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CreateProfileViewModelTest : FunSpec() {
+    init {
+        val dispatcher = StandardTestDispatcher()
+
+        beforeTest {
+            Dispatchers.setMain(dispatcher)
+        }
+
+        afterTest {
+            Dispatchers.resetMain()
+            dispatcher.cancel()
+        }
+
+        // init 의 fetchRandomNickname 이 항상 닉네임을 채우도록 기본 스텁을 준 VM 팩토리.
+        fun createViewModel(
+            randomNickname: String = "기본닉네임",
+            isAvailable: Boolean = true,
+        ): Triple<CreateProfileViewModel, AuthRepository, ProfileRepository> {
+            val authRepository = mock<AuthRepository>()
+            val profileRepository =
+                mock<ProfileRepository> {
+                    everySuspend { getRandomNickname() } returns randomNickname
+                    everySuspend { isNicknameAvailable(any()) } returns isAvailable
+                }
+            val viewModel =
+                CreateProfileViewModel(
+                    authRepository = authRepository,
+                    profileRepository = profileRepository,
+                    nicknameValidator = NicknameValidator(),
+                )
+            return Triple(viewModel, authRepository, profileRepository)
+        }
+
+        test("init() 은 랜덤 닉네임을 받아 state 를 Valid 로 채운다") {
+            runTest {
+                val (viewModel, _, _) = createViewModel(randomNickname = "랜덤닉네임")
+
+                advanceUntilIdle()
+
+                viewModel.state.value.nickname shouldBe "랜덤닉네임"
+                viewModel.state.value.validationResult shouldBe NicknameValidationResult.Valid
+            }
+        }
+
+        test("최소 길이 미만 닉네임은 서버 확인 없이 TooShort 로 표시된다") {
+            runTest {
+                val (viewModel, _, profileRepository) = createViewModel()
+                advanceUntilIdle()
+
+                viewModel.intent(CreateProfileIntent.UpdateNickname("a"))
+                advanceUntilIdle()
+
+                viewModel.state.value.validationResult shouldBe NicknameValidationResult.TooShort
+                // 형식 검증 실패 시 가용성 API 를 호출하지 않아야 한다.
+                verifySuspend(exactly(0)) { profileRepository.isNicknameAvailable("a") }
+            }
+        }
+
+        test("형식이 유효하고 중복이 아니면 Valid 가 된다") {
+            runTest {
+                val (viewModel, _, _) = createViewModel(isAvailable = true)
+                advanceUntilIdle()
+
+                viewModel.intent(CreateProfileIntent.UpdateNickname("거북이"))
+                advanceUntilIdle()
+
+                viewModel.state.value.validationResult shouldBe NicknameValidationResult.Valid
+            }
+        }
+
+        test("형식이 유효하지만 이미 사용 중이면 Duplicate 가 된다") {
+            runTest {
+                val (viewModel, _, _) = createViewModel(isAvailable = false)
+                advanceUntilIdle()
+
+                viewModel.intent(CreateProfileIntent.UpdateNickname("거북이"))
+                advanceUntilIdle()
+
+                viewModel.state.value.validationResult shouldBe NicknameValidationResult.Duplicate
+            }
+        }
+
+        test("확인 가능 상태에서 ClickConfirm 은 가입 완료 후 NavigateBack 을 emit 한다") {
+            runTest {
+                val (viewModel, authRepository, _) =
+                    createViewModel(randomNickname = "랜덤닉네임")
+                everySuspend {
+                    authRepository.completeRegistration(any(), any())
+                } returns AuthSession(accessToken = "access", refreshToken = "refresh")
+                advanceUntilIdle()
+
+                viewModel.sideEffect.test {
+                    viewModel.intent(CreateProfileIntent.ClickConfirm)
+                    advanceUntilIdle()
+
+                    awaitItem() shouldBe CreateProfileSideEffect.NavigateBack
+                }
+                verifySuspend(exactly(1)) {
+                    authRepository.completeRegistration(
+                        nickname = "랜덤닉네임",
+                        termsAgreed = true,
+                    )
+                }
+            }
+        }
+
+        test("ClickBack 은 NavigateBack 을 emit 한다") {
+            runTest {
+                val (viewModel, _, _) = createViewModel()
+                advanceUntilIdle()
+
+                viewModel.sideEffect.test {
+                    viewModel.intent(CreateProfileIntent.ClickBack)
+                    advanceUntilIdle()
+
+                    awaitItem() shouldBe CreateProfileSideEffect.NavigateBack
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

`caro-compose-review` 스킬을 PR #65(프로필 생성 화면)에 적용해 나온 컨벤션 정합성 발견 중,
**판단이 필요 없는 항목만** 반영했습니다. (전체 리뷰 기록: `.claude/skills/caro-compose-review/examples/pr-65-create-profile.md`, 별도 PR)

## 변경 내용

| 항목 | 변경 | 근거 |
|---|---|---|
| Koin DSL | `ProfileModule`의 `viewModel`을 단축 DSL `viewModel<CreateProfileViewModel>()`로 변경 + import 정리(`plugin.module.dsl`로 통일) | Koin 컴파일러 플러그인 컨벤션 |
| 파일 레이아웃 | `CreateProfileRoute.kt`를 `route/` 패키지로 이동 + `NavigationModule` import 갱신 | feature 모듈 `route/<Name>Route.kt` 규칙 (home과 동일) |
| 테스트 | `CreateProfileViewModelTest` 추가 (Kotest FunSpec + Mokkery + Turbine) | feature kover 50% 라인 커버리지 게이트 |

테스트 케이스: 랜덤닉네임 init / 길이 미달(TooShort, 가용성 API 미호출) / 유효+미중복(Valid) / 유효+중복(Duplicate) / ClickConfirm→가입완료+NavigateBack / ClickBack→NavigateBack. (프로젝트 첫 Mokkery 사용)

## 의도적으로 제외 (판단 필요)

- **닉네임 중복확인 실패 시 `Valid` 폴백** — `// TODO: 서버 에러 처리 UI 확정 시` 주석대로 에러 UI 제품 결정 선행 필요
- **매직 `28.dp`(PageHorizontalPadding)** — 대응 spacing 토큰 부재(xl2=24 / xl3=32). 토큰화 시 디자인 변경 → 디자이너 확정 필요

## 검증

- `./gradlew :feature:profile:spotlessApply` — 통과
- `./gradlew :feature:profile:testAndroidHostTest` — **6 passed, 0 failed**
- `./gradlew :androidApp:installDevDebug` — 빌드·설치 성공
- 에뮬레이터 런타임 — 앱 기동 정상, `initKoin()`(새 `profileModule`)·네비게이션 그래프 로드 시 **크래시/Koin DI 오류 없음**, Splash→Login 네비게이션 동작 확인
- 한계: CreateProfile 화면은 소셜 로그인 뒤라 인증 없이 그 화면까지 진입하지 못해 `CreateProfileViewModel`의 런타임 DI 해소는 직접 확인하지 못함. 다만 컴파일 통과 + 단위 테스트(동일 3개 의존성으로 VM 생성) + 변경 전과 동일한 빈 그래프로 동등성 확보.