### PR TITLE
[Feat] 디자인 시스템 최신화

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/components/CaroTextArea.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/components/CaroTextArea.kt
@@ -112,7 +112,7 @@ private fun TextAreaBox(
         }
     val borderColor =
         when {
-            !enabled -> CaroTheme.color.border.disable
+            !enabled -> CaroTheme.color.border.disabled
             isFocused -> CaroTheme.color.border.brand
             else -> CaroTheme.color.border.secondary
         }

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/components/CaroTextArea.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/components/CaroTextArea.kt
@@ -201,7 +201,7 @@ private fun CaroTextAreaWithTitlePreview() {
             header = {
                 Text(
                     text = "자기소개",
-                    style = CaroTheme.typography.label1.bold,
+                    style = CaroTheme.typography.label1,
                     color = CaroTheme.color.text.primary,
                 )
             },
@@ -224,12 +224,12 @@ private fun CaroTextAreaRequiredPreview() {
                 ) {
                     Text(
                         text = "자기소개",
-                        style = CaroTheme.typography.label1.bold,
+                        style = CaroTheme.typography.label1,
                         color = CaroTheme.color.text.primary,
                     )
                     Text(
                         text = "*",
-                        style = CaroTheme.typography.label1.bold,
+                        style = CaroTheme.typography.label1,
                         color = CaroTheme.color.text.accent,
                     )
                 }
@@ -249,7 +249,7 @@ private fun CaroTextAreaWithCaptionPreview() {
             header = {
                 Text(
                     text = "자기소개",
-                    style = CaroTheme.typography.label1.bold,
+                    style = CaroTheme.typography.label1,
                     color = CaroTheme.color.text.primary,
                 )
             },
@@ -277,7 +277,7 @@ private fun CaroTextAreaWithCounterPreview() {
             header = {
                 Text(
                     text = "자기소개",
-                    style = CaroTheme.typography.label1.bold,
+                    style = CaroTheme.typography.label1,
                     color = CaroTheme.color.text.primary,
                 )
             },
@@ -317,12 +317,12 @@ private fun CaroTextAreaFilledPreview() {
                 ) {
                     Text(
                         text = "자기소개",
-                        style = CaroTheme.typography.label1.bold,
+                        style = CaroTheme.typography.label1,
                         color = CaroTheme.color.text.primary,
                     )
                     Text(
                         text = "*",
-                        style = CaroTheme.typography.label1.bold,
+                        style = CaroTheme.typography.label1,
                         color = CaroTheme.color.text.accent,
                     )
                 }
@@ -369,7 +369,7 @@ private fun CaroTextAreaOverflowPreview() {
             header = {
                 Text(
                     text = "자기소개",
-                    style = CaroTheme.typography.label1.bold,
+                    style = CaroTheme.typography.label1,
                     color = CaroTheme.color.text.primary,
                 )
             },
@@ -402,7 +402,7 @@ private fun CaroTextAreaCustomFooterPreview() {
             header = {
                 Text(
                     text = "자기소개",
-                    style = CaroTheme.typography.label1.bold,
+                    style = CaroTheme.typography.label1,
                     color = CaroTheme.color.text.primary,
                 )
             },
@@ -428,7 +428,7 @@ private fun CaroTextAreaDisabledPreview() {
             header = {
                 Text(
                     text = "자기소개",
-                    style = CaroTheme.typography.label1.bold,
+                    style = CaroTheme.typography.label1,
                     color = CaroTheme.color.text.disable,
                 )
             },

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/components/CaroTextField.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/components/CaroTextField.kt
@@ -210,7 +210,7 @@ private fun CaroTextFieldWithTitlePreview() {
             header = {
                 Text(
                     text = "닉네임",
-                    style = CaroTheme.typography.label1.bold,
+                    style = CaroTheme.typography.label1,
                     color = CaroTheme.color.text.primary,
                 )
             },
@@ -233,12 +233,12 @@ private fun CaroTextFieldRequiredPreview() {
                 ) {
                     Text(
                         text = "닉네임",
-                        style = CaroTheme.typography.label1.bold,
+                        style = CaroTheme.typography.label1,
                         color = CaroTheme.color.text.primary,
                     )
                     Text(
                         text = "*",
-                        style = CaroTheme.typography.label1.bold,
+                        style = CaroTheme.typography.label1,
                         color = CaroTheme.color.text.accent,
                     )
                 }
@@ -262,7 +262,7 @@ private fun CaroTextFieldWithCtaPreview() {
                 ) {
                     Text(
                         text = "닉네임",
-                        style = CaroTheme.typography.label1.bold,
+                        style = CaroTheme.typography.label1,
                         color = CaroTheme.color.text.primary,
                     )
                     Row(
@@ -302,7 +302,7 @@ private fun CaroTextFieldWithCaptionPreview() {
             header = {
                 Text(
                     text = "닉네임",
-                    style = CaroTheme.typography.label1.bold,
+                    style = CaroTheme.typography.label1,
                     color = CaroTheme.color.text.primary,
                 )
             },
@@ -330,7 +330,7 @@ private fun CaroTextFieldWithCounterPreview() {
             header = {
                 Text(
                     text = "닉네임",
-                    style = CaroTheme.typography.label1.bold,
+                    style = CaroTheme.typography.label1,
                     color = CaroTheme.color.text.primary,
                 )
             },
@@ -369,12 +369,12 @@ private fun CaroTextFieldFilledPreview() {
                 ) {
                     Text(
                         text = "닉네임",
-                        style = CaroTheme.typography.label1.bold,
+                        style = CaroTheme.typography.label1,
                         color = CaroTheme.color.text.primary,
                     )
                     Text(
                         text = "*",
-                        style = CaroTheme.typography.label1.bold,
+                        style = CaroTheme.typography.label1,
                         color = CaroTheme.color.text.accent,
                     )
                 }
@@ -420,7 +420,7 @@ private fun CaroTextFieldCustomFooterPreview() {
             header = {
                 Text(
                     text = "닉네임",
-                    style = CaroTheme.typography.label1.bold,
+                    style = CaroTheme.typography.label1,
                     color = CaroTheme.color.text.primary,
                 )
             },
@@ -446,7 +446,7 @@ private fun CaroTextFieldDisabledPreview() {
             header = {
                 Text(
                     text = "닉네임",
-                    style = CaroTheme.typography.label1.bold,
+                    style = CaroTheme.typography.label1,
                     color = CaroTheme.color.text.disable,
                 )
             },

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/components/Snackbar.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/components/Snackbar.kt
@@ -80,7 +80,7 @@ fun CaroSnackbar(
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            style = CaroTheme.typography.body2.regular,
+            style = CaroTheme.typography.body3,
             text = snackbarData.visuals.message,
             textAlign = TextAlign.Center,
             color = CaroTheme.color.text.inverse,

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/themes/CaroColor.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/themes/CaroColor.kt
@@ -60,26 +60,25 @@ data class CaroColor(
         val error: Color = Red700,
         val info: Color = Blue600,
         val watermark: Color = Gray100,
-        val accent: Color = Blue500,
+        val accent: Color = Red500,
     )
 
     @Immutable
     data class IconColor(
         val primary: Color = Gray900,
         val secondary: Color = Gray700,
-        val tertiary: Color = Blue100,
+        val tertiary: Color = Gray500,
         val disable: Color = Gray400,
         val inverse: Color = White100,
         val brand: Color = Blue500,
         val warning: Color = Yellow700,
         val error: Color = Red700,
-        val accent: Color = Blue500,
+        val accent: Color = Red500,
     )
 
     @Immutable
     data class BackgroundColor(
         val primary: Color = Gray100,
-        val secondary: Color = Blue500,
         val brand: Color = Blue500,
     )
 
@@ -92,9 +91,8 @@ data class CaroColor(
         val brand: Color = Blue500,
         val warning: Color = Yellow100,
         val error: Color = Red100,
-        val disable: Color = Gray400,
+        val disabled: Color = Gray400,
         val info: Color = Blue100,
-        val watermark: Color = Gray100,
         val accent: Color = Red500,
     )
 
@@ -103,7 +101,7 @@ data class CaroColor(
         val primary: Color = Gray300,
         val secondary: Color = Gray200,
         val tertiary: Color = Gray100,
-        val disable: Color = Gray200,
+        val disabled: Color = Gray200,
         val brand: Color = Blue500,
         val warning: Color = Yellow300,
         val error: Color = Red300,

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/themes/CaroTypography.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/themes/CaroTypography.kt
@@ -17,6 +17,7 @@ data class CaroTypography(
     val body1: TextStyle,
     val body2: Body2Style,
     val body3: TextStyle,
+    val label1: TextStyle,
     val label2: TextStyle,
     val caption1: TextStyle,
     val robotoLabel1: TextStyle,
@@ -99,6 +100,12 @@ data class CaroTypography(
                     fontWeight = FontWeight.W400,
                     fontSize = 14.sp,
                     lineHeight = 22.sp,
+                ),
+            label1 =
+                TextStyle(
+                    fontFamily = pretendard,
+                    fontWeight = FontWeight.W700,
+                    fontSize = 16.sp,
                 ),
             label2 =
                 TextStyle(

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/themes/CaroTypography.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caro/core/designsystem/themes/CaroTypography.kt
@@ -16,43 +16,25 @@ data class CaroTypography(
     val heading3: TextStyle,
     val body1: TextStyle,
     val body2: Body2Style,
-    val label1: Label1Style,
+    val body3: TextStyle,
+    val label2: TextStyle,
     val caption1: TextStyle,
-    val caption2: Caption2Style,
     val robotoLabel1: TextStyle,
 ) {
-    interface BoldStyle {
-        val bold: TextStyle
+    interface SemiBoldStyle {
+        val semiBold: TextStyle
     }
 
-    interface ReadingStyle {
-        val reading: TextStyle
-    }
-
-    interface RegularStyle {
-        val regular: TextStyle
+    interface MediumStyle {
+        val medium: TextStyle
     }
 
     @Immutable
     data class Body2Style(
-        override val regular: TextStyle,
-        override val reading: TextStyle,
-    ) : ReadingStyle,
-        RegularStyle
-
-    @Immutable
-    data class Label1Style(
-        override val bold: TextStyle,
-        override val regular: TextStyle,
-    ) : BoldStyle,
-        RegularStyle
-
-    @Immutable
-    data class Caption2Style(
-        override val bold: TextStyle,
-        override val regular: TextStyle,
-    ) : BoldStyle,
-        RegularStyle
+        override val semiBold: TextStyle,
+        override val medium: TextStyle,
+    ) : SemiBoldStyle,
+        MediumStyle
 
     companion object {
         fun defaultTypography(
@@ -70,83 +52,65 @@ data class CaroTypography(
                 TextStyle(
                     fontFamily = pretendard,
                     fontWeight = FontWeight.W700,
-                    fontSize = 28.sp,
+                    fontSize = 24.sp,
                 ),
             heading1 =
                 TextStyle(
                     fontFamily = pretendard,
                     fontWeight = FontWeight.W700,
-                    fontSize = 22.sp,
+                    fontSize = 20.sp,
                 ),
             heading2 =
                 TextStyle(
                     fontFamily = pretendard,
-                    fontWeight = FontWeight.W700,
+                    fontWeight = FontWeight.W600,
                     fontSize = 18.sp,
                 ),
             heading3 =
                 TextStyle(
                     fontFamily = pretendard,
-                    fontWeight = FontWeight.W700,
+                    fontWeight = FontWeight.W500,
                     fontSize = 16.sp,
                 ),
             body1 =
                 TextStyle(
                     fontFamily = pretendard,
-                    fontWeight = FontWeight.W500,
+                    fontWeight = FontWeight.W600,
                     fontSize = 16.sp,
                 ),
             body2 =
                 Body2Style(
-                    regular =
-                        TextStyle(
-                            fontFamily = pretendard,
-                            fontWeight = FontWeight.W400,
-                            fontSize = 14.sp,
-                        ),
-                    reading =
-                        TextStyle(
-                            fontFamily = pretendard,
-                            fontWeight = FontWeight.W500,
-                            fontSize = 14.sp,
-                            lineHeight = 22.sp,
-                        ),
-                ),
-            label1 =
-                Label1Style(
-                    bold =
+                    semiBold =
                         TextStyle(
                             fontFamily = pretendard,
                             fontWeight = FontWeight.W600,
                             fontSize = 14.sp,
                         ),
-                    regular =
+                    medium =
                         TextStyle(
                             fontFamily = pretendard,
-                            fontWeight = FontWeight.W400,
+                            fontWeight = FontWeight.W500,
                             fontSize = 14.sp,
                         ),
+                ),
+            body3 =
+                TextStyle(
+                    fontFamily = pretendard,
+                    fontWeight = FontWeight.W400,
+                    fontSize = 14.sp,
+                    lineHeight = 22.sp,
+                ),
+            label2 =
+                TextStyle(
+                    fontFamily = pretendard,
+                    fontWeight = FontWeight.W500,
+                    fontSize = 14.sp,
                 ),
             caption1 =
                 TextStyle(
                     fontFamily = pretendard,
                     fontWeight = FontWeight.W500,
                     fontSize = 12.sp,
-                ),
-            caption2 =
-                Caption2Style(
-                    bold =
-                        TextStyle(
-                            fontFamily = pretendard,
-                            fontWeight = FontWeight.W600,
-                            fontSize = 10.sp,
-                        ),
-                    regular =
-                        TextStyle(
-                            fontFamily = pretendard,
-                            fontWeight = FontWeight.W400,
-                            fontSize = 10.sp,
-                        ),
                 ),
             robotoLabel1 =
                 TextStyle(

--- a/feature/deck/src/commonMain/kotlin/com/whatever/caro/feature/deck/CreateDeckScreen.kt
+++ b/feature/deck/src/commonMain/kotlin/com/whatever/caro/feature/deck/CreateDeckScreen.kt
@@ -210,7 +210,7 @@ private fun RequiredFieldHeader(label: String) {
         )
         Text(
             text = stringResource(Res.string.deck_field_required),
-            style = CaroTheme.typography.label1.bold,
+            style = CaroTheme.typography.label1,
             color = CaroTheme.color.text.accent,
         )
     }
@@ -292,7 +292,7 @@ private fun CtaButton(
     ) {
         Text(
             text = stringResource(Res.string.deck_button_create),
-            style = CaroTheme.typography.label1.regular,
+            style = CaroTheme.typography.label1,
             color = CaroTheme.color.text.inverse,
         )
     }

--- a/feature/login/src/commonMain/kotlin/com/whatever/caro/feature/login/LoginScreen.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caro/feature/login/LoginScreen.kt
@@ -91,7 +91,7 @@ internal fun LoginScreen(
 
             Text(
                 text = stringResource(resource = Res.string.login_text_bottom_terms_of_service),
-                style = CaroTheme.typography.label1.regular,
+                style = CaroTheme.typography.label1,
                 color = CaroTheme.color.text.tertiary,
                 textAlign = TextAlign.Center,
             )

--- a/feature/profile/src/commonMain/kotlin/com/whatever/caro/feature/profile/CreateProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/whatever/caro/feature/profile/CreateProfileScreen.kt
@@ -168,7 +168,7 @@ private fun NicknameHeader(onRefreshClick: () -> Unit) {
             )
             Text(
                 text = stringResource(Res.string.profile_field_required),
-                style = CaroTheme.typography.label1.bold,
+                style = CaroTheme.typography.label1,
                 color = CaroTheme.color.text.accent,
             )
         }
@@ -247,7 +247,7 @@ private fun CtaButton(
     ) {
         Text(
             text = stringResource(Res.string.profile_button_create),
-            style = CaroTheme.typography.label1.regular,
+            style = CaroTheme.typography.label1,
             color = CaroTheme.color.text.inverse,
         )
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 작업한 내용
- CaroColor의 색상 명명 정규화 (disable → disabled)
- TextColor와 IconColor의 accent 색상을 Blue500에서 Red500으로 변경
- IconColor의 tertiary 색상을 Blue100에서 Gray500으로 변경
- SurfaceColor의 watermark 프로퍼티 제거
- CaroTextArea의 disabled 상태 border 색상 키 업데이트
- CaroTypography 구조 개선 (Body2Style 인터페이스 재구성)
- CaroTypography에 body3, label2 프로퍼티 추가

## PR 포인트
### 디자인 시스템 명명 규칙 정규화
- disable에서 disabled로 통일하여 명명 일관성 강화
- CaroColor의 TextColor, IconColor, SurfaceColor, BorderColor의 disabled 상태 정의 통합

### 색상 시스템 업데이트
- accent 색상을 Red500으로 통일하여 강조 표현 강화
- IconColor의 tertiary를 Gray500으로 변경하여 시각 계층 개선
- 미사용 watermark 속성 제거로 색상 팔레트 정리

### 타이포그래피 구조 개선
- Body2Style의 ReadingStyle, RegularStyle을 SemiBoldStyle, MediumStyle로 재구성
- body3, label2 타입 추가로 타이포그래피 세분화
- 기존 label1, caption2 관련 불필요한 타입 정의 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->