### PR TITLE
[Feat] 덱 생성 API 연동

### DIFF
--- a/core/data/src/commonMain/kotlin/com/whatever/caro/core/data/di/RepositoryModule.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caro/core/data/di/RepositoryModule.kt
@@ -5,6 +5,8 @@ import com.whatever.caro.core.data.repository.AuthRepository
 import com.whatever.caro.core.data.repository.AuthRepositoryImpl
 import com.whatever.caro.core.data.repository.FcmTokenRepository
 import com.whatever.caro.core.data.repository.FcmTokenRepositoryImpl
+import com.whatever.caro.core.data.repository.deck.DeckRepository
+import com.whatever.caro.core.data.repository.deck.DeckRepositoryImpl
 import com.whatever.caro.core.data.repository.profile.ProfileRepository
 import com.whatever.caro.core.data.repository.profile.ProfileRepositoryImpl
 import com.whatever.caro.core.remote.auth.AuthTokenProvider
@@ -18,4 +20,5 @@ val dataModule =
         single<AuthRepositoryImpl>() bind AuthRepository::class
         single<AuthTokenProviderImpl>() bind AuthTokenProvider::class
         single<ProfileRepositoryImpl>() bind ProfileRepository::class
+        single<DeckRepositoryImpl>() bind DeckRepository::class
     }

--- a/core/data/src/commonMain/kotlin/com/whatever/caro/core/data/repository/deck/DeckRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caro/core/data/repository/deck/DeckRepository.kt
@@ -1,0 +1,8 @@
+package com.whatever.caro.core.data.repository.deck
+
+interface DeckRepository {
+    suspend fun createDeck(
+        name: String,
+        description: String,
+    )
+}

--- a/core/data/src/commonMain/kotlin/com/whatever/caro/core/data/repository/deck/DeckRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caro/core/data/repository/deck/DeckRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.whatever.caro.core.data.repository.deck
+
+import com.whatever.caro.core.remote.datasource.deck.DeckDataSource
+import com.whatever.caro.core.remote.dto.deck.request.CreateDeckRequest
+
+internal class DeckRepositoryImpl(
+    private val deckDataSource: DeckDataSource,
+) : DeckRepository {
+    override suspend fun createDeck(
+        name: String,
+        description: String,
+    ) {
+        val request =
+            CreateDeckRequest(
+                name = name,
+                description = description,
+            )
+        deckDataSource.createDeck(request = request)
+    }
+}

--- a/core/designsystem/src/commonMain/composeResources/values-ko/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-ko/strings.xml
@@ -31,4 +31,5 @@
     <string name="deck_tip_label">TIP</string>
     <string name="deck_tip_max_cards">한 덱에 최대 200장의 카드를 담을 수 있어요.</string>
     <string name="deck_button_create">만들기</string>
+    <string name="deck_toast_create_error">덱 만들기에 실패했어요. 잠시 후 다시 시도해주세요.</string>
 </resources>

--- a/core/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -34,4 +34,5 @@
 	<string name="deck_tip_label">TIP</string>
 	<string name="deck_tip_max_cards">You can add up to 200 cards per deck.</string>
 	<string name="deck_button_create">Create</string>
+	<string name="deck_toast_create_error">Failed to create the deck. Please try again.</string>
 </resources>

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/datasource/deck/DeckDataSource.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/datasource/deck/DeckDataSource.kt
@@ -1,0 +1,8 @@
+package com.whatever.caro.core.remote.datasource.deck
+
+import com.whatever.caro.core.remote.dto.deck.request.CreateDeckRequest
+import com.whatever.caro.core.remote.dto.deck.response.CreateDeckResponse
+
+interface DeckDataSource {
+    suspend fun createDeck(request: CreateDeckRequest): CreateDeckResponse
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/datasource/deck/RemoteDeckDataSourceImpl.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/datasource/deck/RemoteDeckDataSourceImpl.kt
@@ -1,0 +1,11 @@
+package com.whatever.caro.core.remote.datasource.deck
+
+import com.whatever.caro.core.remote.api.DeckApi
+import com.whatever.caro.core.remote.dto.deck.request.CreateDeckRequest
+import com.whatever.caro.core.remote.dto.deck.response.CreateDeckResponse
+
+internal class RemoteDeckDataSourceImpl(
+    private val deckApi: DeckApi,
+) : DeckDataSource {
+    override suspend fun createDeck(request: CreateDeckRequest): CreateDeckResponse = deckApi.requestCreateDeck(request = request)
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/di/RemoteModule.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/di/RemoteModule.kt
@@ -4,6 +4,8 @@ import com.whatever.caro.core.remote.datasource.RemoteAuthDataSource
 import com.whatever.caro.core.remote.datasource.RemoteAuthDataSourceImpl
 import com.whatever.caro.core.remote.datasource.RemoteNonAuthDataSource
 import com.whatever.caro.core.remote.datasource.RemoteNonAuthDataSourceImpl
+import com.whatever.caro.core.remote.datasource.deck.DeckDataSource
+import com.whatever.caro.core.remote.datasource.deck.RemoteDeckDataSourceImpl
 import com.whatever.caro.core.remote.datasource.profile.ProfileDataSource
 import com.whatever.caro.core.remote.datasource.profile.RemoteProfileDataSourceImpl
 import com.whatever.caro.core.remote.di.qualifier.NetworkClient
@@ -27,4 +29,6 @@ val remoteModule =
         }
 
         single<RemoteProfileDataSourceImpl>() bind ProfileDataSource::class
+
+        single<RemoteDeckDataSourceImpl>() bind DeckDataSource::class
     }

--- a/feature/deck/src/commonMain/kotlin/com/whatever/caro/feature/deck/CreateDeckRoute.kt
+++ b/feature/deck/src/commonMain/kotlin/com/whatever/caro/feature/deck/CreateDeckRoute.kt
@@ -4,9 +4,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import caromobile.core.designsystem.generated.resources.Res
+import caromobile.core.designsystem.generated.resources.deck_toast_create_error
+import com.whatever.caro.core.designsystem.components.LocalSnackbarHostState
+import com.whatever.caro.core.designsystem.components.showSnackbarMessage
 import com.whatever.caro.core.navigator.contract.NavCommand
 import com.whatever.caro.core.navigator.dispatcher.NavigationDispatcher
 import com.whatever.caro.feature.deck.mvi.CreateDeckSideEffect
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun CreateDeckRoute(
@@ -14,12 +19,22 @@ fun CreateDeckRoute(
     navDispatcher: NavigationDispatcher,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackbarHost = LocalSnackbarHostState.current
+    val createErrorMessage = stringResource(Res.string.deck_toast_create_error)
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is CreateDeckSideEffect.NavigateBack -> {
                     navDispatcher.emit(command = NavCommand.Back)
+                }
+
+                is CreateDeckSideEffect.ShowError -> {
+                    showSnackbarMessage(
+                        coroutineScope = this,
+                        snackbarHostState = snackbarHost,
+                        message = createErrorMessage,
+                    )
                 }
             }
         }

--- a/feature/deck/src/commonMain/kotlin/com/whatever/caro/feature/deck/CreateDeckViewModel.kt
+++ b/feature/deck/src/commonMain/kotlin/com/whatever/caro/feature/deck/CreateDeckViewModel.kt
@@ -1,12 +1,16 @@
 package com.whatever.caro.feature.deck
 
+import com.whatever.caro.core.data.repository.deck.DeckRepository
+import com.whatever.caro.core.data.util.suspendRunCatching
 import com.whatever.caro.core.viewmodel.BaseViewModel
 import com.whatever.caro.feature.deck.mvi.CreateDeckIntent
 import com.whatever.caro.feature.deck.mvi.CreateDeckSideEffect
 import com.whatever.caro.feature.deck.mvi.CreateDeckState
+import io.github.aakira.napier.Napier
 
-class CreateDeckViewModel :
-    BaseViewModel<CreateDeckState, CreateDeckIntent, CreateDeckSideEffect>(
+class CreateDeckViewModel(
+    private val deckRepository: DeckRepository,
+) : BaseViewModel<CreateDeckState, CreateDeckIntent, CreateDeckSideEffect>(
         initialState = CreateDeckState(),
     ) {
     override suspend fun handleIntent(intent: CreateDeckIntent) {
@@ -28,7 +32,20 @@ class CreateDeckViewModel :
 
     private fun handleConfirm() {
         if (currentState.isConfirmEnabled.not()) return
-        // TODO: 덱 생성 API 연동 (서버 스펙 확정 후 DeckRepository 호출)
-        postSideEffect(CreateDeckSideEffect.NavigateBack)
+        reduce { copy(isLoading = true) }
+        launch {
+            suspendRunCatching {
+                deckRepository.createDeck(
+                    name = currentState.name,
+                    description = currentState.description,
+                )
+            }.onSuccess {
+                postSideEffect(CreateDeckSideEffect.NavigateBack)
+            }.onFailure { throwable ->
+                Napier.e(throwable = throwable) { "createDeck failed" }
+                reduce { copy(isLoading = false) }
+                postSideEffect(CreateDeckSideEffect.ShowError)
+            }
+        }
     }
 }

--- a/feature/deck/src/commonMain/kotlin/com/whatever/caro/feature/deck/mvi/CreateDeckSideEffect.kt
+++ b/feature/deck/src/commonMain/kotlin/com/whatever/caro/feature/deck/mvi/CreateDeckSideEffect.kt
@@ -4,4 +4,6 @@ import com.whatever.caro.core.viewmodel.contract.UiSideEffect
 
 sealed interface CreateDeckSideEffect : UiSideEffect {
     data object NavigateBack : CreateDeckSideEffect
+
+    data object ShowError : CreateDeckSideEffect
 }

--- a/feature/deck/src/commonTest/kotlin/CreateDeckViewModelTest.kt
+++ b/feature/deck/src/commonTest/kotlin/CreateDeckViewModelTest.kt
@@ -1,8 +1,15 @@
 import app.cash.turbine.test
+import com.whatever.caro.core.data.repository.deck.DeckRepository
 import com.whatever.caro.feature.deck.CreateDeckViewModel
 import com.whatever.caro.feature.deck.DeckInputLimits
 import com.whatever.caro.feature.deck.mvi.CreateDeckIntent
 import com.whatever.caro.feature.deck.mvi.CreateDeckSideEffect
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
@@ -18,6 +25,11 @@ class CreateDeckViewModelTest : FunSpec() {
     init {
         val testDispatcher = StandardTestDispatcher()
 
+        fun viewModelWith(
+            deckRepository: DeckRepository =
+                mock { everySuspend { createDeck(any(), any()) } returns Unit },
+        ) = CreateDeckViewModel(deckRepository)
+
         beforeTest {
             Dispatchers.setMain(testDispatcher)
         }
@@ -28,7 +40,7 @@ class CreateDeckViewModelTest : FunSpec() {
 
         test("이름은 NAME_MAX(50)자에서 잘린다") {
             runTest(testDispatcher) {
-                val viewModel = CreateDeckViewModel()
+                val viewModel = viewModelWith()
 
                 viewModel.intent(CreateDeckIntent.UpdateName("가".repeat(60)))
                 advanceUntilIdle()
@@ -39,7 +51,7 @@ class CreateDeckViewModelTest : FunSpec() {
 
         test("설명은 DESC_MAX(500)자에서 잘린다") {
             runTest(testDispatcher) {
-                val viewModel = CreateDeckViewModel()
+                val viewModel = viewModelWith()
 
                 viewModel.intent(CreateDeckIntent.UpdateDescription("a".repeat(600)))
                 advanceUntilIdle()
@@ -50,7 +62,7 @@ class CreateDeckViewModelTest : FunSpec() {
 
         test("이름과 설명이 모두 채워졌을 때만 isConfirmEnabled가 true다") {
             runTest(testDispatcher) {
-                val viewModel = CreateDeckViewModel()
+                val viewModel = viewModelWith()
 
                 viewModel.intent(CreateDeckIntent.UpdateName("영어 단어 2000개"))
                 advanceUntilIdle()
@@ -64,7 +76,7 @@ class CreateDeckViewModelTest : FunSpec() {
 
         test("ClickBack은 NavigateBack을 방출한다") {
             runTest(testDispatcher) {
-                val viewModel = CreateDeckViewModel()
+                val viewModel = viewModelWith()
 
                 viewModel.sideEffect.test {
                     viewModel.intent(CreateDeckIntent.ClickBack)
@@ -73,9 +85,11 @@ class CreateDeckViewModelTest : FunSpec() {
             }
         }
 
-        test("입력 완료 후 ClickConfirm은 NavigateBack을 방출한다") {
+        test("입력 완료 후 ClickConfirm은 덱을 생성하고 NavigateBack을 방출한다") {
             runTest(testDispatcher) {
-                val viewModel = CreateDeckViewModel()
+                val deckRepository =
+                    mock<DeckRepository> { everySuspend { createDeck(any(), any()) } returns Unit }
+                val viewModel = viewModelWith(deckRepository)
 
                 viewModel.intent(CreateDeckIntent.UpdateName("영어 단어 2000개"))
                 viewModel.intent(CreateDeckIntent.UpdateDescription("일상에서 많이 쓰는 단어"))
@@ -85,6 +99,33 @@ class CreateDeckViewModelTest : FunSpec() {
                     viewModel.intent(CreateDeckIntent.ClickConfirm)
                     awaitItem() shouldBe CreateDeckSideEffect.NavigateBack
                 }
+                verifySuspend {
+                    deckRepository.createDeck(
+                        name = "영어 단어 2000개",
+                        description = "일상에서 많이 쓰는 단어",
+                    )
+                }
+            }
+        }
+
+        test("덱 생성 실패 시 ShowError를 방출하고 isLoading이 false로 복귀한다") {
+            runTest(testDispatcher) {
+                val deckRepository =
+                    mock<DeckRepository> {
+                        everySuspend { createDeck(any(), any()) } throws RuntimeException("network error")
+                    }
+                val viewModel = viewModelWith(deckRepository)
+
+                viewModel.intent(CreateDeckIntent.UpdateName("영어 단어 2000개"))
+                viewModel.intent(CreateDeckIntent.UpdateDescription("일상에서 많이 쓰는 단어"))
+                advanceUntilIdle()
+
+                viewModel.sideEffect.test {
+                    viewModel.intent(CreateDeckIntent.ClickConfirm)
+                    awaitItem() shouldBe CreateDeckSideEffect.ShowError
+                }
+
+                viewModel.state.value.isLoading shouldBe false
             }
         }
     }


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업한 내용
- 덱 만들기 화면의 만들기를 덱을 생성(POST /v1/decks)하도록 연동했습니다.
- 만드는 중에는 만들기 버튼을 비활성화해 중복 생성을 막고, 성공하면 이전 화면으로 돌아갑니다.
- 실패하면 화면에 머문 채 스낵바로 알려줍니다. 로그인 화면의 에러 토스트와 같은 방식입니다.

## 공유사항
- `DeckRepository.createDeck`은 반환값이 없습니다. 응답의 id가 nullable인 데다 화면에서는 성공/실패만 필요해서 굳이 돌려주지 않았습니다. 나중에 상세 진입 등으로 id가 필요해지면 그때 추가하면 됩니다.
- 에뮬레이터에서 로그인 → 덱 만들기 → 생성까지 직접 돌려봤고 요청은 정상적으로 나갑니다. 다만 테스트 계정에서는 서버가 403(A002, 접근 권한 없음)을 돌려줘서 생성 성공(2xx)까지는 확인하지 못했습니다. 서버 권한 쪽 확인이 필요해 보입니다.
- 실패 스낵바는 일반 문구로 띄웁니다. 서버가 주는 구체 메시지를 그대로 보여주려면 `ErrorDetailDto`의 `traceId`/`fieldErrors`에 기본값이 없어 에러 응답 파싱이 깨지는 기존 문제를 먼저 고쳐야 합니다. 전 엔드포인트 공통이라 이 PR에서는 건드리지 않았습니다.

## 검증
- `./gradlew :feature:deck:testAndroidHostTest` — 통과 (성공/실패 경로 포함)
- `./gradlew :feature:deck:koverVerify`, `./gradlew spotlessCheck` — 통과
- `./gradlew :androidApp:assembleDevDebug` — 빌드 성공


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 작업한 내용
- DeckRepository 인터페이스 및 구현체(DeckRepositoryImpl) 추가
- DeckDataSource 인터페이스 및 원격 구현체(RemoteDeckDataSourceImpl) 추가
- DI 모듈(RemoteModule, RepositoryModule)에 덱 관련 의존성 바인딩 추가
- CreateDeckViewModel에 DeckRepository 주입 및 API 호출 로직 구현
- CreateDeckRoute에서 에러 발생 시 스낵바 메시지 표시
- CreateDeckSideEffect에 ShowError 사이드이펙트 추가
- 덱 생성 실패 메시지용 문자열 리소스 추가(한글/영문)
- CreateDeckViewModel 단위 테스트 추가(성공/실패 케이스)

## PR 포인트
### 덱 생성 API 통합
- 버튼 클릭 시 실제 서버 요청(POST /v1/decks) 실행
- 요청 중 버튼 비활성화로 중복 제출 방지
- 성공 시 이전 화면으로 돌아감

### 에러 처리
- 요청 실패 시 스낵바로 에러 메시지 표시
- 에러 발생 후에도 화면 유지로 재시도 가능
- 로그인 화면과 동일한 에러 처리 패턴 적용

### 테스트 및 검증
- 성공/실패 케이스 모두 단위 테스트로 검증
- 자동화된 모든 검사 통과(단위 테스트, 코드 커버리지, 코드 스타일, 빌드)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->