### PR TITLE
[Feat] Swagger API 스펙 동기화

### DIFF
--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/api/DeckCardInformationApi.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/api/DeckCardInformationApi.kt
@@ -1,0 +1,16 @@
+package com.whatever.caro.core.remote.api
+
+import com.whatever.caro.core.remote.dto.deckCardInformation.response.DeckCardResponse
+import com.whatever.caro.core.remote.dto.deckCardInformation.response.DeckListResponse
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.Path
+
+internal interface DeckCardInformationApi {
+    @GET("v1/decks")
+    suspend fun requestDecks(): List<DeckListResponse>
+
+    @GET("v2/decks/{deckId}/cards")
+    suspend fun requestCardsByDeck(
+        @Path("deckId") deckId: Long,
+    ): List<DeckCardResponse>
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/api/StudySessionApi.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/api/StudySessionApi.kt
@@ -1,0 +1,33 @@
+package com.whatever.caro.core.remote.api
+
+import com.whatever.caro.core.remote.dto.studySession.request.EvaluatedCardRequest
+import com.whatever.caro.core.remote.dto.studySession.request.StartDailyStudyRequest
+import com.whatever.caro.core.remote.dto.studySession.response.DailyStudyResponse
+import com.whatever.caro.core.remote.dto.studySession.response.DailyStudySummaryResponse
+import com.whatever.caro.core.remote.dto.studySession.response.EvaluationResponse
+import de.jensklingenberg.ktorfit.http.Body
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.Header
+import de.jensklingenberg.ktorfit.http.POST
+import de.jensklingenberg.ktorfit.http.Path
+import de.jensklingenberg.ktorfit.http.Query
+
+internal interface StudySessionApi {
+    @GET("v1/study-sessions/daily/summary")
+    suspend fun requestTodayDailyStudySummary(
+        @Query("deckId") deckId: Long,
+    ): DailyStudySummaryResponse
+
+    @POST("v1/study-sessions/daily")
+    suspend fun requestStartDailyStudy(
+        @Header("Idempotency-Key") idempotencyKey: String,
+        @Body request: StartDailyStudyRequest,
+    ): DailyStudyResponse
+
+    @POST("v1/study-sessions/{sessionId}/evaluations")
+    suspend fun requestEvaluate(
+        @Path("sessionId") sessionId: Long,
+        @Header("Idempotency-Key") idempotencyKey: String,
+        @Body request: List<EvaluatedCardRequest>,
+    ): EvaluationResponse
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/api/UserApi.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/api/UserApi.kt
@@ -1,7 +1,11 @@
 package com.whatever.caro.core.remote.api
 
+import com.whatever.caro.core.remote.dto.user.request.UpdateNicknameRequest
 import com.whatever.caro.core.remote.dto.user.response.NicknameCheckResponse
+import com.whatever.caro.core.remote.dto.user.response.UpdateNicknameResponse
+import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.PATCH
 import de.jensklingenberg.ktorfit.http.Path
 
 internal interface UserApi {
@@ -9,4 +13,9 @@ internal interface UserApi {
     suspend fun requestCheckNicknameAvailability(
         @Path("nickname") nickname: String,
     ): NicknameCheckResponse
+
+    @PATCH("v1/users/me/nickname")
+    suspend fun requestUpdateNickname(
+        @Body request: UpdateNicknameRequest,
+    ): UpdateNicknameResponse
 }

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/di/ApiModule.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/di/ApiModule.kt
@@ -3,12 +3,16 @@ package com.whatever.caro.core.remote.di
 import com.whatever.caro.core.remote.api.AuthApi
 import com.whatever.caro.core.remote.api.CardControllerApi
 import com.whatever.caro.core.remote.api.DeckApi
+import com.whatever.caro.core.remote.api.DeckCardInformationApi
 import com.whatever.caro.core.remote.api.NicknameApi
+import com.whatever.caro.core.remote.api.StudySessionApi
 import com.whatever.caro.core.remote.api.UserApi
 import com.whatever.caro.core.remote.api.createAuthApi
 import com.whatever.caro.core.remote.api.createCardControllerApi
 import com.whatever.caro.core.remote.api.createDeckApi
+import com.whatever.caro.core.remote.api.createDeckCardInformationApi
 import com.whatever.caro.core.remote.api.createNicknameApi
+import com.whatever.caro.core.remote.api.createStudySessionApi
 import com.whatever.caro.core.remote.api.createUserApi
 import com.whatever.caro.core.remote.di.qualifier.NetworkClient
 import de.jensklingenberg.ktorfit.Ktorfit
@@ -33,8 +37,16 @@ val apiModule =
             get<Ktorfit>(named(NetworkClient.Caro.AUTH)).createCardControllerApi()
         }
 
+        single<DeckCardInformationApi> {
+            get<Ktorfit>(named(NetworkClient.Caro.AUTH)).createDeckCardInformationApi()
+        }
+
         single<NicknameApi> {
             get<Ktorfit>(named(NetworkClient.Caro.AUTH)).createNicknameApi()
+        }
+
+        single<StudySessionApi> {
+            get<Ktorfit>(named(NetworkClient.Caro.AUTH)).createStudySessionApi()
         }
 
         single<UserApi> {

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/deckCardInformation/response/DeckCardResponse.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/deckCardInformation/response/DeckCardResponse.kt
@@ -1,0 +1,25 @@
+package com.whatever.caro.core.remote.dto.deckCardInformation.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class DeckCardResponse(
+    val cardId: Long?,
+    val fields: Map<String, String>?,
+    val badge: BadgeDto?,
+    val reviewCount: Int?,
+) {
+    @Serializable
+    enum class BadgeDto {
+        @SerialName("NEW")
+        NEW,
+
+        @SerialName("REVIEW")
+        REVIEW,
+
+        @SerialName("HARD")
+        HARD,
+    }
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/deckCardInformation/response/DeckListResponse.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/deckCardInformation/response/DeckListResponse.kt
@@ -1,0 +1,14 @@
+package com.whatever.caro.core.remote.dto.deckCardInformation.response
+
+import com.whatever.caro.core.remote.dto.studySession.response.StudySessionProgressResponseDto
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class DeckListResponse(
+    val deckId: Long?,
+    val name: String?,
+    val description: String?,
+    val cardCount: Int?,
+    val progress: StudySessionProgressResponseDto?,
+)

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/request/EvaluatedCardRequest.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/request/EvaluatedCardRequest.kt
@@ -1,0 +1,24 @@
+package com.whatever.caro.core.remote.dto.studySession.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class EvaluatedCardRequest(
+    val cardId: Long?,
+    val rating: RatingDto?,
+    val timeMs: Int?,
+) {
+    @Serializable
+    enum class RatingDto {
+        @SerialName("AGAIN")
+        AGAIN,
+
+        @SerialName("FAIR")
+        FAIR,
+
+        @SerialName("EASY")
+        EASY,
+    }
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/request/StartDailyStudyRequest.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/request/StartDailyStudyRequest.kt
@@ -1,0 +1,9 @@
+package com.whatever.caro.core.remote.dto.studySession.request
+
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class StartDailyStudyRequest(
+    val deckId: Long?,
+)

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/Completed.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/Completed.kt
@@ -1,0 +1,14 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+@SerialName("COMPLETED")
+data class Completed(
+    val sessionId: Long?,
+    val studiedCardCount: Int?,
+    val totalCardCount: Int?,
+) : DailyStudyResponse,
+    DailyStudySummaryResponse

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/DailyStudyResponse.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/DailyStudyResponse.kt
@@ -1,0 +1,11 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("type")
+sealed interface DailyStudyResponse

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/DailyStudySummaryResponse.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/DailyStudySummaryResponse.kt
@@ -1,0 +1,11 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("type")
+sealed interface DailyStudySummaryResponse

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/EvaluationResponse.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/EvaluationResponse.kt
@@ -1,0 +1,24 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class EvaluationResponse(
+    val evaluatedCardIds: List<Long>?,
+    val failedCardIds: List<Long>?,
+    val sessionStatus: SessionStatusDto?,
+) {
+    @Serializable
+    enum class SessionStatusDto {
+        @SerialName("ACTIVE")
+        ACTIVE,
+
+        @SerialName("COMPLETED")
+        COMPLETED,
+
+        @SerialName("STOPPED")
+        STOPPED,
+    }
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/InProgress.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/InProgress.kt
@@ -1,0 +1,15 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+@SerialName("IN_PROGRESS")
+data class InProgress(
+    val sessionId: Long?,
+    val studiedCardCount: Int?,
+    val totalCardCount: Int?,
+    val cards: List<StudyCardItemDto>?,
+) : DailyStudyResponse,
+    DailyStudySummaryResponse

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/NotStarted.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/NotStarted.kt
@@ -1,0 +1,12 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+@SerialName("NOT_STARTED")
+data class NotStarted(
+    val studiedCardCount: Int?,
+    val totalCardCount: Int?,
+) : DailyStudySummaryResponse

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/RestDay.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/RestDay.kt
@@ -1,0 +1,11 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+@SerialName("REST_DAY")
+data object RestDay :
+    DailyStudyResponse,
+    DailyStudySummaryResponse

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/StudyCardItemDto.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/StudyCardItemDto.kt
@@ -1,0 +1,10 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class StudyCardItemDto(
+    val cardId: Long?,
+    val fields: Map<String, String>?,
+)

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/StudySessionProgressResponseDto.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/StudySessionProgressResponseDto.kt
@@ -1,0 +1,28 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class StudySessionProgressResponseDto(
+    val state: StateDto?,
+    val sessionId: Long?,
+    val studiedCardCount: Int?,
+    val totalCardCount: Int?,
+) {
+    @Serializable
+    enum class StateDto {
+        @SerialName("NOT_STARTED")
+        NOT_STARTED,
+
+        @SerialName("IN_PROGRESS")
+        IN_PROGRESS,
+
+        @SerialName("COMPLETED")
+        COMPLETED,
+
+        @SerialName("REST_DAY")
+        REST_DAY,
+    }
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/user/request/UpdateNicknameRequest.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/user/request/UpdateNicknameRequest.kt
@@ -1,0 +1,10 @@
+package com.whatever.caro.core.remote.dto.user.request
+
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class UpdateNicknameRequest(
+    /** 변경할 닉네임 */
+    val nickname: String,
+)

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/user/response/UpdateNicknameResponse.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/user/response/UpdateNicknameResponse.kt
@@ -1,0 +1,12 @@
+package com.whatever.caro.core.remote.dto.user.response
+
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class UpdateNicknameResponse(
+    /** 사용자 ID */
+    val userId: Long?,
+    /** 변경된 닉네임 */
+    val nickname: String?,
+)


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업한 내용
- Swagger/OpenAPI v1 스펙 기준으로 Deck Card Information, StudySession API 인터페이스를 추가했습니다.
- 관련 DTO와 Koin apiModule 바인딩을 동기화했습니다.

## PR 포인트
- 스펙 버전: v1
- 검증: `./gradlew spotlessApply`, `bash .claude/skills/swagger-sync/scripts/verify.sh` 통과
- 전날 workflow PR 없음: 신규 PR 생성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 작업한 내용
- DeckCardInformationApi 추가 (덱 목록 조회, 특정 덱의 카드 목록 조회)
- StudySessionApi 추가 (일일 학습 요약 조회, 일일 학습 시작, 카드 평가 제출)
- ApiModule에 DeckCardInformationApi, StudySessionApi DI 바인딩 추가
- 덱 카드 정보 관련 DTO 추가 (DeckListResponse, DeckCardResponse)
- 학습 세션 관련 요청 DTO 추가 (StartDailyStudyRequest, EvaluatedCardRequest)
- 학습 세션 관련 응답 DTO 추가 (DailyStudyResponse, DailyStudySummaryResponse, EvaluationResponse, Completed, InProgress, NotStarted, RestDay, StudyCardItemDto, StudySessionProgressResponseDto)

## PR 포인트
### Swagger/OpenAPI v1 스펙 동기화
- Swagger/OpenAPI v1 명세를 기반으로 API 인터페이스 및 관련 DTO 동기화
- 모든 DTO는 Swagger 자동 생성 명시 주석을 포함하며 직렬화 설정(`@Serializable`, `@SerialName`) 완료
- 복합 응답 타입(DailyStudyResponse, DailyStudySummaryResponse)은 sealed interface 기반 다형성 설계로 구현
- 모든 변경사항이 `./gradlew spotlessApply` 코드 포맷팅 검증 및 `bash .claude/skills/swagger-sync/scripts/verify.sh` 동기화 검증 완료

<!-- end of auto-generated comment: release notes by coderabbit.ai -->