### PR TITLE
[Feat] Swagger API 스펙 동기화

### DIFF
--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/api/DeckCardInformationApi.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/api/DeckCardInformationApi.kt
@@ -1,0 +1,16 @@
+package com.whatever.caro.core.remote.api
+
+import com.whatever.caro.core.remote.dto.deckCardInformation.response.DeckCardResponse
+import com.whatever.caro.core.remote.dto.deckCardInformation.response.DeckListResponse
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.Path
+
+internal interface DeckCardInformationApi {
+    @GET("v1/decks")
+    suspend fun requestDecks(): List<DeckListResponse>
+
+    @GET("v2/decks/{deckId}/cards")
+    suspend fun requestCardsByDeck(
+        @Path("deckId") deckId: Long,
+    ): List<DeckCardResponse>
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/api/StudySessionApi.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/api/StudySessionApi.kt
@@ -1,0 +1,33 @@
+package com.whatever.caro.core.remote.api
+
+import com.whatever.caro.core.remote.dto.studySession.request.EvaluatedCardRequest
+import com.whatever.caro.core.remote.dto.studySession.request.StartDailyStudyRequest
+import com.whatever.caro.core.remote.dto.studySession.response.DailyStudyResponse
+import com.whatever.caro.core.remote.dto.studySession.response.DailyStudySummaryResponse
+import com.whatever.caro.core.remote.dto.studySession.response.EvaluationResponse
+import de.jensklingenberg.ktorfit.http.Body
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.Header
+import de.jensklingenberg.ktorfit.http.POST
+import de.jensklingenberg.ktorfit.http.Path
+import de.jensklingenberg.ktorfit.http.Query
+
+internal interface StudySessionApi {
+    @GET("v1/study-sessions/daily/summary")
+    suspend fun requestTodayDailyStudySummary(
+        @Query("deckId") deckId: Long,
+    ): DailyStudySummaryResponse
+
+    @POST("v1/study-sessions/daily")
+    suspend fun requestStartDailyStudy(
+        @Header("Idempotency-Key") idempotencyKey: String,
+        @Body request: StartDailyStudyRequest,
+    ): DailyStudyResponse
+
+    @POST("v1/study-sessions/{sessionId}/evaluations")
+    suspend fun requestEvaluate(
+        @Path("sessionId") sessionId: Long,
+        @Header("Idempotency-Key") idempotencyKey: String,
+        @Body request: List<EvaluatedCardRequest>,
+    ): EvaluationResponse
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/api/UserApi.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/api/UserApi.kt
@@ -1,7 +1,11 @@
 package com.whatever.caro.core.remote.api
 
+import com.whatever.caro.core.remote.dto.user.request.UpdateNicknameRequest
 import com.whatever.caro.core.remote.dto.user.response.NicknameCheckResponse
+import com.whatever.caro.core.remote.dto.user.response.UpdateNicknameResponse
+import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.PATCH
 import de.jensklingenberg.ktorfit.http.Path
 
 internal interface UserApi {
@@ -9,4 +13,9 @@ internal interface UserApi {
     suspend fun requestCheckNicknameAvailability(
         @Path("nickname") nickname: String,
     ): NicknameCheckResponse
+
+    @PATCH("v1/users/me/nickname")
+    suspend fun requestUpdateNickname(
+        @Body request: UpdateNicknameRequest,
+    ): UpdateNicknameResponse
 }

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/di/ApiModule.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/di/ApiModule.kt
@@ -3,12 +3,16 @@ package com.whatever.caro.core.remote.di
 import com.whatever.caro.core.remote.api.AuthApi
 import com.whatever.caro.core.remote.api.CardControllerApi
 import com.whatever.caro.core.remote.api.DeckApi
+import com.whatever.caro.core.remote.api.DeckCardInformationApi
 import com.whatever.caro.core.remote.api.NicknameApi
+import com.whatever.caro.core.remote.api.StudySessionApi
 import com.whatever.caro.core.remote.api.UserApi
 import com.whatever.caro.core.remote.api.createAuthApi
 import com.whatever.caro.core.remote.api.createCardControllerApi
 import com.whatever.caro.core.remote.api.createDeckApi
+import com.whatever.caro.core.remote.api.createDeckCardInformationApi
 import com.whatever.caro.core.remote.api.createNicknameApi
+import com.whatever.caro.core.remote.api.createStudySessionApi
 import com.whatever.caro.core.remote.api.createUserApi
 import com.whatever.caro.core.remote.di.qualifier.NetworkClient
 import de.jensklingenberg.ktorfit.Ktorfit
@@ -33,8 +37,16 @@ val apiModule =
             get<Ktorfit>(named(NetworkClient.Caro.AUTH)).createCardControllerApi()
         }
 
+        single<DeckCardInformationApi> {
+            get<Ktorfit>(named(NetworkClient.Caro.AUTH)).createDeckCardInformationApi()
+        }
+
         single<NicknameApi> {
             get<Ktorfit>(named(NetworkClient.Caro.AUTH)).createNicknameApi()
+        }
+
+        single<StudySessionApi> {
+            get<Ktorfit>(named(NetworkClient.Caro.AUTH)).createStudySessionApi()
         }
 
         single<UserApi> {

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/deckCardInformation/response/DeckCardResponse.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/deckCardInformation/response/DeckCardResponse.kt
@@ -1,0 +1,25 @@
+package com.whatever.caro.core.remote.dto.deckCardInformation.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class DeckCardResponse(
+    val cardId: Long?,
+    val fields: Map<String, String>?,
+    val badge: BadgeDto?,
+    val reviewCount: Int?,
+) {
+    @Serializable
+    enum class BadgeDto {
+        @SerialName("NEW")
+        NEW,
+
+        @SerialName("REVIEW")
+        REVIEW,
+
+        @SerialName("HARD")
+        HARD,
+    }
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/deckCardInformation/response/DeckListResponse.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/deckCardInformation/response/DeckListResponse.kt
@@ -1,0 +1,14 @@
+package com.whatever.caro.core.remote.dto.deckCardInformation.response
+
+import com.whatever.caro.core.remote.dto.studySession.response.StudySessionProgressResponseDto
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class DeckListResponse(
+    val deckId: Long?,
+    val name: String?,
+    val description: String?,
+    val cardCount: Int?,
+    val progress: StudySessionProgressResponseDto?,
+)

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/request/EvaluatedCardRequest.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/request/EvaluatedCardRequest.kt
@@ -1,0 +1,24 @@
+package com.whatever.caro.core.remote.dto.studySession.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class EvaluatedCardRequest(
+    val cardId: Long?,
+    val rating: RatingDto?,
+    val timeMs: Int?,
+) {
+    @Serializable
+    enum class RatingDto {
+        @SerialName("AGAIN")
+        AGAIN,
+
+        @SerialName("FAIR")
+        FAIR,
+
+        @SerialName("EASY")
+        EASY,
+    }
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/request/StartDailyStudyRequest.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/request/StartDailyStudyRequest.kt
@@ -1,0 +1,9 @@
+package com.whatever.caro.core.remote.dto.studySession.request
+
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class StartDailyStudyRequest(
+    val deckId: Long?,
+)

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/Completed.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/Completed.kt
@@ -1,0 +1,14 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+@SerialName("COMPLETED")
+data class Completed(
+    val sessionId: Long?,
+    val studiedCardCount: Int?,
+    val totalCardCount: Int?,
+) : DailyStudyResponse,
+    DailyStudySummaryResponse

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/DailyStudyResponse.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/DailyStudyResponse.kt
@@ -1,0 +1,11 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("type")
+sealed interface DailyStudyResponse

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/DailyStudySummaryResponse.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/DailyStudySummaryResponse.kt
@@ -1,0 +1,11 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("type")
+sealed interface DailyStudySummaryResponse

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/EvaluationResponse.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/EvaluationResponse.kt
@@ -1,0 +1,24 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class EvaluationResponse(
+    val evaluatedCardIds: List<Long>?,
+    val failedCardIds: List<Long>?,
+    val sessionStatus: SessionStatusDto?,
+) {
+    @Serializable
+    enum class SessionStatusDto {
+        @SerialName("ACTIVE")
+        ACTIVE,
+
+        @SerialName("COMPLETED")
+        COMPLETED,
+
+        @SerialName("STOPPED")
+        STOPPED,
+    }
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/InProgress.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/InProgress.kt
@@ -1,0 +1,15 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+@SerialName("IN_PROGRESS")
+data class InProgress(
+    val sessionId: Long?,
+    val studiedCardCount: Int?,
+    val totalCardCount: Int?,
+    val cards: List<StudyCardItemDto>?,
+) : DailyStudyResponse,
+    DailyStudySummaryResponse

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/NotStarted.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/NotStarted.kt
@@ -1,0 +1,12 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+@SerialName("NOT_STARTED")
+data class NotStarted(
+    val studiedCardCount: Int?,
+    val totalCardCount: Int?,
+) : DailyStudySummaryResponse

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/RestDay.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/RestDay.kt
@@ -1,0 +1,11 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+@SerialName("REST_DAY")
+data object RestDay :
+    DailyStudyResponse,
+    DailyStudySummaryResponse

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/StudyCardItemDto.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/StudyCardItemDto.kt
@@ -1,0 +1,10 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class StudyCardItemDto(
+    val cardId: Long?,
+    val fields: Map<String, String>?,
+)

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/StudySessionProgressResponseDto.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/studySession/response/StudySessionProgressResponseDto.kt
@@ -1,0 +1,28 @@
+package com.whatever.caro.core.remote.dto.studySession.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class StudySessionProgressResponseDto(
+    val state: StateDto?,
+    val sessionId: Long?,
+    val studiedCardCount: Int?,
+    val totalCardCount: Int?,
+) {
+    @Serializable
+    enum class StateDto {
+        @SerialName("NOT_STARTED")
+        NOT_STARTED,
+
+        @SerialName("IN_PROGRESS")
+        IN_PROGRESS,
+
+        @SerialName("COMPLETED")
+        COMPLETED,
+
+        @SerialName("REST_DAY")
+        REST_DAY,
+    }
+}

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/user/request/UpdateNicknameRequest.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/user/request/UpdateNicknameRequest.kt
@@ -1,0 +1,10 @@
+package com.whatever.caro.core.remote.dto.user.request
+
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class UpdateNicknameRequest(
+    /** 변경할 닉네임 */
+    val nickname: String,
+)

--- a/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/user/response/UpdateNicknameResponse.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caro/core/remote/dto/user/response/UpdateNicknameResponse.kt
@@ -1,0 +1,12 @@
+package com.whatever.caro.core.remote.dto.user.response
+
+import kotlinx.serialization.Serializable
+
+// AUTO-GENERATED FROM SWAGGER — 직접 수정하지 마세요
+@Serializable
+data class UpdateNicknameResponse(
+    /** 사용자 ID */
+    val userId: Long?,
+    /** 변경된 닉네임 */
+    val nickname: String?,
+)


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업한 내용
- Swagger/OpenAPI 스펙 기준 DTO와 API 인터페이스를 동기화했습니다.
- StudySession, Deck Card Information, User API와 Koin binding을 반영했습니다.

## PR 포인트
- Swagger spec version: v1
- 검증: `./gradlew spotlessApply`, `bash .claude/skills/swagger-sync/scripts/verify.sh` 통과
- 전날 PR 이어서 작업: 아니오

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 작업한 내용
- Swagger/OpenAPI 명세 기반 StudySessionApi 인터페이스 추가 (일일 학습 요약 조회, 학습 시작, 평가 요청)
- Swagger/OpenAPI 명세 기반 DeckCardInformationApi 인터페이스 추가 (데크 목록 조회, 데크별 카드 목록 조회)
- UserApi에 닉네임 업데이트 기능 추가
- Koin 의존성 주입 설정 업데이트 (DeckCardInformationApi, StudySessionApi 바인딩 추가)
- 스터디 세션 관련 DTO 추가 (EvaluatedCardRequest, StartDailyStudyRequest, Completed, DailyStudyResponse, DailyStudySummaryResponse, EvaluationResponse, InProgress, NotStarted, RestDay, StudyCardItemDto, StudySessionProgressResponseDto)
- 데크 카드 정보 관련 DTO 추가 (DeckCardResponse, DeckListResponse)
- 사용자 API 관련 DTO 추가 (UpdateNicknameRequest, UpdateNicknameResponse)

## PR 포인트
### Swagger 명세 동기화
- Swagger/OpenAPI v1 명세를 기반으로 API 인터페이스 및 DTO를 자동 생성 방식으로 추가했습니다.
- `@SerialName` 어노테이션을 통해 Kotlinx Serialization 직렬화 매핑이 정확하게 설정되었습니다.
- 모든 DTO 필드는 nullable 타입으로 정의하여 API 응답의 선택적 필드를 안전하게 처리합니다.

### sealed interface 기반 다형 응답 처리
- DailyStudyResponse와 DailyStudySummaryResponse를 sealed interface로 정의하고, `@JsonClassDiscriminator("type")`를 활용한 런타임 타입 판별을 구현했습니다.
- 응답 상태에 따라 RestDay, NotStarted, InProgress, Completed 등 구체적인 구현체를 통해 타입 안전성을 확보했습니다.

### 멱등성 지원 및 요청 표준화
- StudySessionApi의 학습 시작 및 평가 요청에 `Idempotency-Key` 헤더를 포함하여 멱등성을 보장합니다.
- StartDailyStudyRequest, EvaluatedCardRequest 등 요청 DTO는 명확한 필드 정의로 API 계약을 명확히 합니다.

### 코드 품질 검증
- `./gradlew spotlessApply`와 커스텀 검증 스크립트(`bash .claude/skills/swagger-sync/scripts/verify.sh`)를 통과한 변경사항으로 코드 스타일과 정합성이 확보됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->