### PR TITLE
[Refactor] 누락된 테스트 코드 및 kover 자동 설정 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,15 @@ subprojects {
     }
 }
 
+// caro.kover 를 적용한 모듈을 자동 수집한다. 새 모듈이 caro.kover 를 적용하면
+// 이 목록을 직접 수정하지 않아도 koverAll* 집계 대상에 자동으로 포함된다.
+val koverEnabledProjects = mutableListOf<Project>()
+subprojects {
+    plugins.withId("caro.kover") {
+        koverEnabledProjects.add(this@subprojects)
+    }
+}
+
 /**
  * Kover 적용된 모듈에 대한 XML 리포트 생성
  * 터미널에서 ./gradlew koverAllXmlReport 를 실행
@@ -85,12 +94,7 @@ tasks.register("koverAllXmlReport") {
     group = "verification"
     description = "Generate Kover XML reports for all coverage-enabled modules"
 
-    dependsOn(
-        ":feature:login:koverXmlReport",
-        ":feature:home:koverXmlReport",
-        ":feature:profile:koverXmlReport",
-        ":core:data:koverXmlReport"
-    )
+    dependsOn(provider { koverEnabledProjects.map { "${it.path}:koverXmlReport" } })
 }
 
 /**
@@ -101,10 +105,5 @@ tasks.register("koverAllVerify") {
     group = "verification"
     description = "Verify Kover coverage for all coverage-enabled modules"
 
-    dependsOn(
-        ":feature:login:koverVerify",
-        ":feature:home:koverVerify",
-        ":feature:profile:koverVerify",
-        ":core:data:koverVerify"
-    )
+    dependsOn(provider { koverEnabledProjects.map { "${it.path}:koverVerify" } })
 }

--- a/core/data/src/commonTest/kotlin/com/whatever/caro/core/data/repository/auth/AuthRepositoryImplTest.kt
+++ b/core/data/src/commonTest/kotlin/com/whatever/caro/core/data/repository/auth/AuthRepositoryImplTest.kt
@@ -1,0 +1,168 @@
+package com.whatever.caro.core.data.repository.auth
+
+import com.whatever.caro.core.datastore.datasource.LocalAuthDataSource
+import com.whatever.caro.core.model.auth.AuthSession
+import com.whatever.caro.core.model.auth.SocialLoginType
+import com.whatever.caro.core.model.exception.CaroAuthException
+import com.whatever.caro.core.remote.datasource.RemoteAuthDataSource
+import com.whatever.caro.core.remote.datasource.RemoteNonAuthDataSource
+import com.whatever.caro.core.remote.dto.auth.request.RefreshTokenRequest
+import com.whatever.caro.core.remote.dto.auth.request.SocialLoginRequest
+import com.whatever.caro.core.remote.dto.auth.response.SocialLoginResponse
+import com.whatever.caro.core.remote.dto.auth.response.TokenResponse
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+
+class AuthRepositoryImplTest : FunSpec() {
+    init {
+        fun repositoryWith(
+            remoteAuthDataSource: RemoteAuthDataSource = mock(),
+            remoteNonAuthDataSource: RemoteNonAuthDataSource = mock(),
+            localAuthDataSource: LocalAuthDataSource = mock(),
+        ) = AuthRepositoryImpl(
+            remoteAuthDataSource = remoteAuthDataSource,
+            remoteNonAuthDataSource = remoteNonAuthDataSource,
+            localAuthDataSource = localAuthDataSource,
+        )
+
+        test("loginWithSocial은 발급된 토큰을 저장하고 AuthSession을 반환한다") {
+            runTest {
+                val remoteNonAuthDataSource =
+                    mock<RemoteNonAuthDataSource> {
+                        everySuspend { socialLogin(any()) } returns
+                            SocialLoginResponse(
+                                accessToken = "access",
+                                refreshToken = "refresh",
+                                isRegistrationComplete = true,
+                            )
+                    }
+                val localAuthDataSource =
+                    mock<LocalAuthDataSource> {
+                        everySuspend { saveTokens(any(), any()) } returns Unit
+                    }
+                val repository =
+                    repositoryWith(
+                        remoteNonAuthDataSource = remoteNonAuthDataSource,
+                        localAuthDataSource = localAuthDataSource,
+                    )
+
+                val result =
+                    repository.loginWithSocial(
+                        provider = SocialLoginType.GOOGLE,
+                        idToken = "idToken",
+                    )
+
+                result shouldBe AuthSession(accessToken = "access", refreshToken = "refresh")
+                verifySuspend {
+                    remoteNonAuthDataSource.socialLogin(
+                        SocialLoginRequest(provider = SocialLoginType.GOOGLE, idToken = "idToken"),
+                    )
+                    localAuthDataSource.saveTokens(accessToken = "access", refreshToken = "refresh")
+                }
+            }
+        }
+
+        test("logout은 원격 로그아웃 후 로컬 토큰을 비운다") {
+            runTest {
+                val remoteAuthDataSource =
+                    mock<RemoteAuthDataSource> { everySuspend { logout() } returns Unit }
+                val localAuthDataSource =
+                    mock<LocalAuthDataSource> { everySuspend { clear() } returns Unit }
+                val repository =
+                    repositoryWith(
+                        remoteAuthDataSource = remoteAuthDataSource,
+                        localAuthDataSource = localAuthDataSource,
+                    )
+
+                repository.logout()
+
+                verifySuspend {
+                    remoteAuthDataSource.logout()
+                    localAuthDataSource.clear()
+                }
+            }
+        }
+
+        test("completeRegistration은 발급된 토큰을 저장하고 AuthSession을 반환한다") {
+            runTest {
+                val remoteAuthDataSource =
+                    mock<RemoteAuthDataSource> {
+                        everySuspend { completeRegistration(any()) } returns
+                            TokenResponse(accessToken = "access", refreshToken = "refresh")
+                    }
+                val localAuthDataSource =
+                    mock<LocalAuthDataSource> {
+                        everySuspend { saveTokens(any(), any()) } returns Unit
+                    }
+                val repository =
+                    repositoryWith(
+                        remoteAuthDataSource = remoteAuthDataSource,
+                        localAuthDataSource = localAuthDataSource,
+                    )
+
+                val result =
+                    repository.completeRegistration(
+                        nickname = "caro",
+                        termsAgreed = true,
+                    )
+
+                result shouldBe AuthSession(accessToken = "access", refreshToken = "refresh")
+                verifySuspend {
+                    localAuthDataSource.saveTokens(accessToken = "access", refreshToken = "refresh")
+                }
+            }
+        }
+
+        test("refreshToken은 저장된 토큰으로 갱신 후 새 토큰을 저장한다") {
+            runTest {
+                val localAuthDataSource =
+                    mock<LocalAuthDataSource> {
+                        everySuspend { fetchAccessToken() } returns "oldAccess"
+                        everySuspend { fetchRefreshToken() } returns "oldRefresh"
+                        everySuspend { saveTokens(any(), any()) } returns Unit
+                    }
+                val remoteNonAuthDataSource =
+                    mock<RemoteNonAuthDataSource> {
+                        everySuspend { refreshToken(any()) } returns
+                            TokenResponse(accessToken = "newAccess", refreshToken = "newRefresh")
+                    }
+                val repository =
+                    repositoryWith(
+                        remoteNonAuthDataSource = remoteNonAuthDataSource,
+                        localAuthDataSource = localAuthDataSource,
+                    )
+
+                repository.refreshToken()
+
+                verifySuspend {
+                    remoteNonAuthDataSource.refreshToken(
+                        RefreshTokenRequest(accessToken = "oldAccess", refreshToken = "oldRefresh"),
+                    )
+                    localAuthDataSource.saveTokens(accessToken = "newAccess", refreshToken = "newRefresh")
+                }
+            }
+        }
+
+        test("refreshToken은 저장된 토큰이 비어 있으면 TokenEmpty를 던진다") {
+            runTest {
+                val localAuthDataSource =
+                    mock<LocalAuthDataSource> {
+                        everySuspend { fetchAccessToken() } returns null
+                        everySuspend { fetchRefreshToken() } returns "oldRefresh"
+                    }
+                val repository = repositoryWith(localAuthDataSource = localAuthDataSource)
+
+                shouldThrow<CaroAuthException.TokenEmpty> {
+                    repository.refreshToken()
+                }
+            }
+        }
+    }
+}

--- a/core/data/src/commonTest/kotlin/com/whatever/caro/core/data/repository/deck/DeckRepositoryImplTest.kt
+++ b/core/data/src/commonTest/kotlin/com/whatever/caro/core/data/repository/deck/DeckRepositoryImplTest.kt
@@ -1,0 +1,35 @@
+package com.whatever.caro.core.data.repository.deck
+
+import com.whatever.caro.core.remote.datasource.deck.DeckDataSource
+import com.whatever.caro.core.remote.dto.deck.request.CreateDeckRequest
+import com.whatever.caro.core.remote.dto.deck.response.CreateDeckResponse
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import kotlinx.coroutines.test.runTest
+
+class DeckRepositoryImplTest : FunSpec() {
+    init {
+        test("createDeck은 이름과 설명으로 덱 생성 요청을 전달한다") {
+            runTest {
+                val deckDataSource =
+                    mock<DeckDataSource> {
+                        everySuspend { createDeck(any()) } returns
+                            CreateDeckResponse(id = 1L, deckName = "영어 단어", deckDescription = "일상 단어")
+                    }
+                val repository = DeckRepositoryImpl(deckDataSource)
+
+                repository.createDeck(name = "영어 단어", description = "일상 단어")
+
+                verifySuspend {
+                    deckDataSource.createDeck(
+                        CreateDeckRequest(name = "영어 단어", description = "일상 단어"),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/core/data/src/commonTest/kotlin/com/whatever/caro/core/data/repository/fcm/FcmTokenRepositoryImplTest.kt
+++ b/core/data/src/commonTest/kotlin/com/whatever/caro/core/data/repository/fcm/FcmTokenRepositoryImplTest.kt
@@ -1,0 +1,16 @@
+package com.whatever.caro.core.data.repository.fcm
+
+import io.kotest.core.spec.style.FunSpec
+import kotlinx.coroutines.test.runTest
+
+class FcmTokenRepositoryImplTest : FunSpec() {
+    init {
+        test("syncToken은 예외 없이 토큰을 처리한다") {
+            runTest {
+                val repository = FcmTokenRepositoryImpl()
+
+                repository.syncToken("fcm-token")
+            }
+        }
+    }
+}

--- a/core/data/src/commonTest/kotlin/com/whatever/caro/core/data/repository/profile/ProfileRepositoryImplTest.kt
+++ b/core/data/src/commonTest/kotlin/com/whatever/caro/core/data/repository/profile/ProfileRepositoryImplTest.kt
@@ -1,0 +1,61 @@
+package com.whatever.caro.core.data.repository.profile
+
+import com.whatever.caro.core.remote.datasource.profile.ProfileDataSource
+import com.whatever.caro.core.remote.dto.nickname.response.NicknameResponse
+import com.whatever.caro.core.remote.dto.user.request.UpdateNicknameRequest
+import com.whatever.caro.core.remote.dto.user.response.NicknameCheckResponse
+import com.whatever.caro.core.remote.dto.user.response.UpdateNicknameResponse
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+
+class ProfileRepositoryImplTest : FunSpec() {
+    init {
+        test("getRandomNickname은 응답의 nickname을 반환한다") {
+            runTest {
+                val profileDataSource =
+                    mock<ProfileDataSource> {
+                        everySuspend { getRandomNickname() } returns NicknameResponse(nickname = "캐로")
+                    }
+                val repository = ProfileRepositoryImpl(profileDataSource)
+
+                repository.getRandomNickname() shouldBe "캐로"
+            }
+        }
+
+        test("isNicknameAvailable은 응답의 available 값을 반환한다") {
+            runTest {
+                val profileDataSource =
+                    mock<ProfileDataSource> {
+                        everySuspend { checkNicknameAvailability(any()) } returns
+                            NicknameCheckResponse(nickname = "캐로", available = true)
+                    }
+                val repository = ProfileRepositoryImpl(profileDataSource)
+
+                repository.isNicknameAvailable("캐로") shouldBe true
+            }
+        }
+
+        test("updateNickname은 닉네임 변경 요청을 전달한다") {
+            runTest {
+                val profileDataSource =
+                    mock<ProfileDataSource> {
+                        everySuspend { changeNickname(any()) } returns
+                            UpdateNicknameResponse(userId = 1L, nickname = "캐로")
+                    }
+                val repository = ProfileRepositoryImpl(profileDataSource)
+
+                repository.updateNickname("캐로")
+
+                verifySuspend {
+                    profileDataSource.changeNickname(UpdateNicknameRequest(nickname = "캐로"))
+                }
+            }
+        }
+    }
+}

--- a/feature/login/src/commonTest/kotlin/LoginViewModelTest.kt
+++ b/feature/login/src/commonTest/kotlin/LoginViewModelTest.kt
@@ -1,33 +1,42 @@
+import app.cash.turbine.test
+import com.whatever.caro.core.data.repository.auth.AuthRepository
+import com.whatever.caro.core.model.auth.AuthSession
+import com.whatever.caro.core.model.auth.SocialLoginType
 import com.whatever.caro.core.viewmodel.ExceptionFilter
-import com.whatever.caro.feature.login.di.loginModule
+import com.whatever.caro.feature.login.LoginViewModel
+import com.whatever.caro.feature.login.model.AppleUser
+import com.whatever.caro.feature.login.model.GoogleUser
+import com.whatever.caro.feature.login.model.LoginError
+import com.whatever.caro.feature.login.model.SocialLoginResult
+import com.whatever.caro.feature.login.mvi.LoginIntent
+import com.whatever.caro.feature.login.mvi.LoginSideEffect
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.koin.KoinExtension
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import org.koin.dsl.module
-import org.koin.test.KoinTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class LoginViewModelTest :
-    FunSpec(),
-    KoinTest {
+class LoginViewModelTest : FunSpec() {
     init {
-        extensions(
-            KoinExtension(
-                listOf(
-                    loginModule,
-                    module {
-                        single<ExceptionFilter> { ExceptionFilter.None }
-                    },
-                ),
-            ),
-        )
-
         val testDispatcher = StandardTestDispatcher()
+
+        fun viewModelWith(
+            authRepository: AuthRepository =
+                mock {
+                    everySuspend { loginWithSocial(any(), any()) } returns
+                        AuthSession(accessToken = "access", refreshToken = "refresh")
+                },
+        ) = LoginViewModel(authRepository, ExceptionFilter.None)
 
         beforeTest {
             Dispatchers.setMain(testDispatcher)
@@ -35,7 +44,126 @@ class LoginViewModelTest :
 
         afterTest {
             Dispatchers.resetMain()
-            testDispatcher.cancel()
+        }
+
+        test("구글 로그인 성공 시 GOOGLE 토큰으로 로그인하고 NavigateHome을 방출한다") {
+            runTest(testDispatcher) {
+                val authRepository =
+                    mock<AuthRepository> {
+                        everySuspend { loginWithSocial(any(), any()) } returns
+                            AuthSession(accessToken = "access", refreshToken = "refresh")
+                    }
+                val viewModel = viewModelWith(authRepository)
+
+                viewModel.sideEffect.test {
+                    viewModel.intent(
+                        LoginIntent.ClickGoogleLoginButton(
+                            SocialLoginResult.Success(GoogleUser(idToken = "google-token")),
+                        ),
+                    )
+                    awaitItem() shouldBe LoginSideEffect.NavigateHome
+                }
+
+                viewModel.state.value.isLoading shouldBe false
+                verifySuspend {
+                    authRepository.loginWithSocial(
+                        provider = SocialLoginType.GOOGLE,
+                        idToken = "google-token",
+                    )
+                }
+            }
+        }
+
+        test("애플 로그인 성공 시 APPLE 토큰으로 로그인하고 NavigateHome을 방출한다") {
+            runTest(testDispatcher) {
+                val authRepository =
+                    mock<AuthRepository> {
+                        everySuspend { loginWithSocial(any(), any()) } returns
+                            AuthSession(accessToken = "access", refreshToken = "refresh")
+                    }
+                val viewModel = viewModelWith(authRepository)
+
+                viewModel.sideEffect.test {
+                    viewModel.intent(
+                        LoginIntent.ClickAppleLoginButton(
+                            SocialLoginResult.Success(AppleUser(idToken = "apple-token")),
+                        ),
+                    )
+                    awaitItem() shouldBe LoginSideEffect.NavigateHome
+                }
+
+                verifySuspend {
+                    authRepository.loginWithSocial(
+                        provider = SocialLoginType.APPLE,
+                        idToken = "apple-token",
+                    )
+                }
+            }
+        }
+
+        test("구글 로그인 결과가 Failed면 UNKNOWN 에러 스낵바를 방출한다") {
+            runTest(testDispatcher) {
+                val viewModel = viewModelWith()
+
+                viewModel.sideEffect.test {
+                    viewModel.intent(LoginIntent.ClickGoogleLoginButton(SocialLoginResult.Failed))
+                    awaitItem() shouldBe LoginSideEffect.ShowErrorSnackbar(LoginError.UNKNOWN)
+                }
+            }
+        }
+
+        test("구글 로그인 결과가 UserCancelled면 USER_CANCELLED 에러 스낵바를 방출한다") {
+            runTest(testDispatcher) {
+                val viewModel = viewModelWith()
+
+                viewModel.sideEffect.test {
+                    viewModel.intent(LoginIntent.ClickGoogleLoginButton(SocialLoginResult.UserCancelled))
+                    awaitItem() shouldBe LoginSideEffect.ShowErrorSnackbar(LoginError.USER_CANCELLED)
+                }
+            }
+        }
+
+        test("애플 로그인 결과가 Failed면 UNKNOWN 에러 스낵바를 방출한다") {
+            runTest(testDispatcher) {
+                val viewModel = viewModelWith()
+
+                viewModel.sideEffect.test {
+                    viewModel.intent(LoginIntent.ClickAppleLoginButton(SocialLoginResult.Failed))
+                    awaitItem() shouldBe LoginSideEffect.ShowErrorSnackbar(LoginError.UNKNOWN)
+                }
+            }
+        }
+
+        test("애플 로그인 결과가 UserCancelled면 USER_CANCELLED 에러 스낵바를 방출한다") {
+            runTest(testDispatcher) {
+                val viewModel = viewModelWith()
+
+                viewModel.sideEffect.test {
+                    viewModel.intent(LoginIntent.ClickAppleLoginButton(SocialLoginResult.UserCancelled))
+                    awaitItem() shouldBe LoginSideEffect.ShowErrorSnackbar(LoginError.USER_CANCELLED)
+                }
+            }
+        }
+
+        test("소셜 로그인 호출이 실패하면 UNKNOWN 스낵바를 방출하고 isLoading이 false로 복귀한다") {
+            runTest(testDispatcher) {
+                val authRepository =
+                    mock<AuthRepository> {
+                        everySuspend { loginWithSocial(any(), any()) } throws RuntimeException("network error")
+                    }
+                val viewModel = viewModelWith(authRepository)
+
+                viewModel.sideEffect.test {
+                    viewModel.intent(
+                        LoginIntent.ClickGoogleLoginButton(
+                            SocialLoginResult.Success(GoogleUser(idToken = "google-token")),
+                        ),
+                    )
+                    awaitItem() shouldBe LoginSideEffect.ShowErrorSnackbar(LoginError.UNKNOWN)
+                }
+
+                viewModel.state.value.isLoading shouldBe false
+            }
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 작업한 내용
- Kover 적용 모듈을 하드코딩 대신 자동 수집하도록 build 설정 변경
- `AuthRepositoryImpl`, `DeckRepositoryImpl`, `FcmTokenRepositoryImpl`, `ProfileRepositoryImpl` 테스트 추가
- `LoginViewModelTest`를 Koin 의존성 없이 로컬 mock 기반으로 정리

## PR 포인트
### Kover 자동 설정
- `caro.kover`가 적용된 subproject를 자동으로 모아 Kover 리포트/검증 태스크 의존성을 구성하도록 변경
- 모듈 추가/삭제 시 build script 수정 없이 coverage 대상이 반영되도록 개선

### Repository 테스트 보강
- 인증/덱 생성/FCM 동기화/닉네임 관련 repository 동작을 테스트로 보강
- 요청 전달, 응답 반환, 예외 케이스까지 핵심 플로우를 검증하도록 추가

### LoginViewModel 테스트 정리
- Koin 기반 테스트 의존성을 제거하고 mock 중심으로 전환
- 로그인 성공/실패/취소 시나리오를 로컬 테스트 환경에서 안정적으로 검증하도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->